### PR TITLE
remove obsolete documentation about (removed) end-to-end tests

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -23,9 +23,9 @@ Testrunner:
 DJANGO_SETTINGS_MODULE=config.settings.test ./web_frontend/manage.py test
 ```
 
-## Running the test-suite and integration tests
+## Running the test-suite
 
-There's a Python 3 script to facilitate testing including some docker integration tests.
+There's a Python 3 script to facilitate testing.
 
 It allows some control over what tests to run. Call it with
 ```shell
@@ -33,53 +33,12 @@ It allows some control over what tests to run. Call it with
 ```
 to see what options it provides.
 
-To run tests of all available test types, call it without passing any options (be sure to read the part about
-running end to end test before you are doing this!):
-```shell
-./runtests.py
-```
 
-## Running end to end tests (e2e)
+### Running all tests
 
-### Warnings 
+**Warning**: This will usually take more than 7 minutes to finish
 
-* before doing anything, you *MUST* run `docker-compose run --rm osmplanet` to have the pbf data at hand!
-* It needs a Firefox browser installed (for now)
-* These run for quite a long time (over five Minutes!). 
-* The containers are being destroyed at the beginning (creating a clean state). Resulting in
-    * Only run one test at a time
-    * don't run on production!
-    * don't run docker-compose in parallel
-    * exiting data is being destroyed 
-
-### Prerequisites
-
-An activated virtualenv with requests installed.
-
-```shell
-virtualenv tmp
-. ./tmp/bin/activate
-pip install -r e2e/requirements.txt
-python e2e/e2e_tests.py
-```
-or
-```shell
-RUN_E2E=true ./runtests.py
-```
-or
-```shell
-./runtests.py --end-to-end-tests
-```
-
-To simplify the steps needed, the `runtests.py` can be used to run all tests, as described in the next section.
- 
-## Running all tests
-
-**Warnings**:
-
-* same rules as running e2e test apply
-* it will usually take more than 7 minutes to finish
-* it will create a temporary virtualenv and remove it afterwards again
+To run tests of all available test types, call the script without passing any options:
 
 ```shell
 ./runtests.py


### PR DESCRIPTION
When we removed the end-to-end tests in #401, we forgot to also remove the documentation about them.

### Reviewed by
- [x] @hixi