### PR TITLE
Feature/#343 remove duplication in rest api client http verb methods

### DIFF
--- a/osmaxx/api_client/API_client.py
+++ b/osmaxx/api_client/API_client.py
@@ -30,12 +30,15 @@ class RESTApiJWTClient:
         self.token = None
 
     def get(self, url, params=None, **kwargs):
-        response = requests.get(self._to_fully_qualified_url(url), params=params, **self._data_dict(**kwargs))
-        response.raise_for_status()
-        return response
+        return self._request(requests.get, url, dict(params=params), kwargs)
 
     def post(self, url, json_data=None, **kwargs):
-        response = requests.post(self._to_fully_qualified_url(url), json=json_data, **self._data_dict(**kwargs))
+        return self._request(requests.post, url, dict(json=json_data), kwargs)
+
+    def _request(self, method, url, payload, kwargs):
+        kwargs = self._data_dict(**kwargs)
+        kwargs.update(payload)
+        response = method(self._to_fully_qualified_url(url), **kwargs)
         response.raise_for_status()
         return response
 

--- a/osmaxx/api_client/conversion_api_client.py
+++ b/osmaxx/api_client/conversion_api_client.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 from requests import HTTPError
 from rest_framework.reverse import reverse
 
-from osmaxx.api_client.API_client import RESTApiJWTClient, reasons_for
+from osmaxx.api_client.API_client import JWTClient, reasons_for
 from osmaxx.excerptexport.models import ExtractionOrderState, OutputFile
 from osmaxx.utils import get_default_private_storage
 
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 COUNTRY_ID_PREFIX = 'country-'
 
 
-class ConversionApiClient(RESTApiJWTClient):
+class ConversionApiClient(JWTClient):
     service_base = settings.OSMAXX.get('CONVERSION_SERVICE_URL')
     login_url = '/token-auth/'
 

--- a/tests/api_client/rest_api_client_test.py
+++ b/tests/api_client/rest_api_client_test.py
@@ -16,17 +16,15 @@ def test_get_performs_request(requests_mock):
 
 
 def test_post_performs_request(requests_mock):
-    def json_callback(request, context):
-        assert request.json() == {'pay': 'load'}
-        return {'some response': 'you posted it'}
     requests_mock.post(
         # Expected request:
         'http://example.com/service/uri_base/post/example',
         request_headers={'Content-Type': 'application/json; charset=UTF-8'},
 
         # Response if request matched:
-        json=json_callback
+        json={'some response': 'you posted it'}
     )
     c = RESTApiJWTClient('http://example.com/service/uri_base/')
     response = c.post('post/example', json_data={'pay': 'load'})
+    assert response.request.json() == {'pay': 'load'}
     assert response.json() == {'some response': 'you posted it'}

--- a/tests/api_client/rest_api_client_test.py
+++ b/tests/api_client/rest_api_client_test.py
@@ -1,5 +1,4 @@
 import pytest
-import requests_mock as requests_mock_package
 
 from osmaxx.api_client.API_client import RESTApiJWTClient
 
@@ -20,5 +19,6 @@ def test_get_performs_request(requests_mock):
 
 @pytest.yield_fixture
 def requests_mock():
+    import requests_mock as requests_mock_package
     with requests_mock_package.mock() as m:
         yield m

--- a/tests/api_client/rest_api_client_test.py
+++ b/tests/api_client/rest_api_client_test.py
@@ -1,5 +1,3 @@
-import pytest
-
 from osmaxx.api_client.API_client import RESTApiJWTClient
 
 
@@ -15,10 +13,3 @@ def test_get_performs_request(requests_mock):
     c = RESTApiJWTClient('http://example.com/service/uri_base/')
     response = c.get('get/example')
     assert response.json() == {'some response': 'you got it'}
-
-
-@pytest.yield_fixture
-def requests_mock():
-    import requests_mock
-    with requests_mock.mock() as m:
-        yield m

--- a/tests/api_client/rest_api_client_test.py
+++ b/tests/api_client/rest_api_client_test.py
@@ -1,18 +1,24 @@
+import pytest
 import requests_mock as requests_mock_package
 
 from osmaxx.api_client.API_client import RESTApiJWTClient
 
 
-def test_get_performs_request():
-    with requests_mock_package.mock() as requests_mock:
-        requests_mock.get(
-            # Expected request:
-            'http://example.com/service/uri_base/get/example',
-            request_headers={'Content-Type': 'application/json; charset=UTF-8'},
+def test_get_performs_request(requests_mock):
+    requests_mock.get(
+        # Expected request:
+        'http://example.com/service/uri_base/get/example',
+        request_headers={'Content-Type': 'application/json; charset=UTF-8'},
 
-            # Response if request matched:
-            json={'some response': 'you got it'}
-        )
-        c = RESTApiJWTClient('http://example.com/service/uri_base/')
-        response = c.get('get/example')
-        assert response.json() == {'some response': 'you got it'}
+        # Response if request matched:
+        json={'some response': 'you got it'}
+    )
+    c = RESTApiJWTClient('http://example.com/service/uri_base/')
+    response = c.get('get/example')
+    assert response.json() == {'some response': 'you got it'}
+
+
+@pytest.yield_fixture
+def requests_mock():
+    with requests_mock_package.mock() as m:
+        yield m

--- a/tests/api_client/rest_api_client_test.py
+++ b/tests/api_client/rest_api_client_test.py
@@ -2,12 +2,35 @@ from osmaxx.api_client.API_client import RESTApiJWTClient
 from requests_mock import ANY
 
 
-def test_get_performs_request(requests_mock):
+def test_get_requests_combined_url(requests_mock):
+    """
+    The requested URL is the concatenation of
+    the service_base of the RESTApiJWTClient instance and
+    the relative URL passed to RESTApiJWTClient.get().
+    """
     requests_mock.get(ANY, json={'some response': 'you got it'})
     c = RESTApiJWTClient('http://example.com/service/uri_base/')
     response = c.get('get/example')
     assert response.request.url == 'http://example.com/service/uri_base/get/example'
+
+
+def test_get_specifies_body_content_type(requests_mock):
+    # FIXME: Does this make any sense?
+    # As far as I can tell, the 'Content-Type' in the request headers specifies
+    # the content type of the body of the request, not of the body of the response.
+    # While GET requests can have a body (which the server should ignore if present),
+    # we don't send a body in the request. Specifying an absent body's content type
+    # seems rather nonsensical.
+    requests_mock.get(ANY, json={'some response': 'you got it'})
+    c = RESTApiJWTClient('http://example.com/service/uri_base/')
+    response = c.get('get/example')
     assert response.request.headers['Content-Type'] == 'application/json; charset=UTF-8'
+
+
+def test_get_returns_received_response(requests_mock):
+    requests_mock.get(ANY, json={'some response': 'you got it'})
+    c = RESTApiJWTClient('http://example.com/service/uri_base/')
+    response = c.get('get/example')
     assert response.json() == {'some response': 'you got it'}
 
 

--- a/tests/api_client/rest_api_client_test.py
+++ b/tests/api_client/rest_api_client_test.py
@@ -1,10 +1,11 @@
 from osmaxx.api_client.API_client import RESTApiJWTClient
+from requests_mock import ANY
 
 
 def test_get_performs_request(requests_mock):
     requests_mock.get(
         # Expected request:
-        'http://example.com/service/uri_base/get/example',
+        ANY,
         request_headers={'Content-Type': 'application/json; charset=UTF-8'},
 
         # Response if request matched:
@@ -12,13 +13,14 @@ def test_get_performs_request(requests_mock):
     )
     c = RESTApiJWTClient('http://example.com/service/uri_base/')
     response = c.get('get/example')
+    assert response.request.url == 'http://example.com/service/uri_base/get/example'
     assert response.json() == {'some response': 'you got it'}
 
 
 def test_post_performs_request(requests_mock):
     requests_mock.post(
         # Expected request:
-        'http://example.com/service/uri_base/post/example',
+        ANY,
         request_headers={'Content-Type': 'application/json; charset=UTF-8'},
 
         # Response if request matched:
@@ -26,5 +28,6 @@ def test_post_performs_request(requests_mock):
     )
     c = RESTApiJWTClient('http://example.com/service/uri_base/')
     response = c.post('post/example', json_data={'pay': 'load'})
+    assert response.request.url == 'http://example.com/service/uri_base/post/example'
     assert response.request.json() == {'pay': 'load'}
     assert response.json() == {'some response': 'you posted it'}

--- a/tests/api_client/rest_api_client_test.py
+++ b/tests/api_client/rest_api_client_test.py
@@ -1,15 +1,15 @@
-from osmaxx.api_client.API_client import RESTApiJWTClient
+from osmaxx.api_client.API_client import RESTApiClient
 from requests_mock import ANY
 
 
 def test_get_requests_combined_url(requests_mock):
     """
     The requested URL is the concatenation of
-    the service_base of the RESTApiJWTClient instance and
-    the relative URL passed to RESTApiJWTClient.get().
+    the service_base of the RESTApiClient instance and
+    the relative URL passed to RESTApiClient.get().
     """
     requests_mock.get(ANY)
-    c = RESTApiJWTClient('http://example.com/service/uri_base/')
+    c = RESTApiClient('http://example.com/service/uri_base/')
     response = c.get('get/example')
     assert response.request.url == 'http://example.com/service/uri_base/get/example'
 
@@ -22,21 +22,21 @@ def test_get_specifies_body_content_type(requests_mock):
     # we don't send a body in the request. Specifying an absent body's content type
     # seems rather nonsensical.
     requests_mock.get(ANY)
-    c = RESTApiJWTClient('http://example.com/service/uri_base/')
+    c = RESTApiClient('http://example.com/service/uri_base/')
     response = c.get('get/example')
     assert response.request.headers['Content-Type'] == 'application/json; charset=UTF-8'
 
 
 def test_get_sends_payload_in_query_string(requests_mock):
     requests_mock.get(ANY)
-    c = RESTApiJWTClient('http://example.com/service/uri_base/')
+    c = RESTApiClient('http://example.com/service/uri_base/')
     response = c.get('get/example', params={'some_key': b'a value'})
     assert response.request.url == 'http://example.com/service/uri_base/get/example?some_key=a+value'
 
 
 def test_get_returns_received_response(requests_mock):
     requests_mock.get(ANY, json={'some response': 'you got it'})
-    c = RESTApiJWTClient('http://example.com/service/uri_base/')
+    c = RESTApiClient('http://example.com/service/uri_base/')
     response = c.get('get/example')
     assert response.json() == {'some response': 'you got it'}
 
@@ -44,31 +44,31 @@ def test_get_returns_received_response(requests_mock):
 def test_post_requests_combined_url(requests_mock):
     """
     The requested URL is the concatenation of
-    the service_base of the RESTApiJWTClient instance and
-    the relative URL passed to RESTApiJWTClient.get().
+    the service_base of the RESTApiClient instance and
+    the relative URL passed to RESTApiClient.get().
     """
     requests_mock.post(ANY)
-    c = RESTApiJWTClient('http://example.com/service/uri_base/')
+    c = RESTApiClient('http://example.com/service/uri_base/')
     response = c.post('post/example', json_data={'pay': 'load'})
     assert response.request.url == 'http://example.com/service/uri_base/post/example'
 
 
 def test_post_specifies_body_content_type(requests_mock):
     requests_mock.post(ANY)
-    c = RESTApiJWTClient('http://example.com/service/uri_base/')
+    c = RESTApiClient('http://example.com/service/uri_base/')
     response = c.post('post/example', json_data={'pay': 'load'})
     assert response.request.headers['Content-Type'] == 'application/json; charset=UTF-8'
 
 
 def test_post_sends_payload_as_json_body(requests_mock):
     requests_mock.post(ANY)
-    c = RESTApiJWTClient('http://example.com/service/uri_base/')
+    c = RESTApiClient('http://example.com/service/uri_base/')
     response = c.post('post/example', json_data={'pay': 'load'})
     assert response.request.json() == {'pay': 'load'}
 
 
 def test_post_returns_received_response(requests_mock):
     requests_mock.post(ANY, json={'some response': 'you posted it'})
-    c = RESTApiJWTClient('http://example.com/service/uri_base/')
+    c = RESTApiClient('http://example.com/service/uri_base/')
     response = c.post('post/example', json_data={'pay': 'load'})
     assert response.json() == {'some response': 'you posted it'}

--- a/tests/api_client/rest_api_client_test.py
+++ b/tests/api_client/rest_api_client_test.py
@@ -4,8 +4,8 @@ from osmaxx.api_client.API_client import RESTApiJWTClient
 
 
 def test_get_performs_request():
-    with requests_mock_package.mock() as r_mock:
-        r_mock.get(
+    with requests_mock_package.mock() as requests_mock:
+        requests_mock.get(
             # Expected request:
             'http://example.com/service/uri_base/get/example',
             request_headers={'Content-Type': 'application/json; charset=UTF-8'},

--- a/tests/api_client/rest_api_client_test.py
+++ b/tests/api_client/rest_api_client_test.py
@@ -8,7 +8,7 @@ def test_get_requests_combined_url(requests_mock):
     the service_base of the RESTApiJWTClient instance and
     the relative URL passed to RESTApiJWTClient.get().
     """
-    requests_mock.get(ANY, json={'some response': 'you got it'})
+    requests_mock.get(ANY)
     c = RESTApiJWTClient('http://example.com/service/uri_base/')
     response = c.get('get/example')
     assert response.request.url == 'http://example.com/service/uri_base/get/example'
@@ -21,7 +21,7 @@ def test_get_specifies_body_content_type(requests_mock):
     # While GET requests can have a body (which the server should ignore if present),
     # we don't send a body in the request. Specifying an absent body's content type
     # seems rather nonsensical.
-    requests_mock.get(ANY, json={'some response': 'you got it'})
+    requests_mock.get(ANY)
     c = RESTApiJWTClient('http://example.com/service/uri_base/')
     response = c.get('get/example')
     assert response.request.headers['Content-Type'] == 'application/json; charset=UTF-8'

--- a/tests/api_client/rest_api_client_test.py
+++ b/tests/api_client/rest_api_client_test.py
@@ -27,6 +27,13 @@ def test_get_specifies_body_content_type(requests_mock):
     assert response.request.headers['Content-Type'] == 'application/json; charset=UTF-8'
 
 
+def test_get_sends_payload_in_query_string(requests_mock):
+    requests_mock.get(ANY)
+    c = RESTApiJWTClient('http://example.com/service/uri_base/')
+    response = c.get('get/example', params={'some_key': b'a value'})
+    assert response.request.url == 'http://example.com/service/uri_base/get/example?some_key=a+value'
+
+
 def test_get_returns_received_response(requests_mock):
     requests_mock.get(ANY, json={'some response': 'you got it'})
     c = RESTApiJWTClient('http://example.com/service/uri_base/')

--- a/tests/api_client/rest_api_client_test.py
+++ b/tests/api_client/rest_api_client_test.py
@@ -19,6 +19,6 @@ def test_get_performs_request(requests_mock):
 
 @pytest.yield_fixture
 def requests_mock():
-    import requests_mock as requests_mock_package
-    with requests_mock_package.mock() as m:
+    import requests_mock
+    with requests_mock.mock() as m:
         yield m

--- a/tests/api_client/rest_api_client_test.py
+++ b/tests/api_client/rest_api_client_test.py
@@ -34,11 +34,34 @@ def test_get_returns_received_response(requests_mock):
     assert response.json() == {'some response': 'you got it'}
 
 
-def test_post_performs_request(requests_mock):
-    requests_mock.post(ANY, json={'some response': 'you posted it'})
+def test_post_requests_combined_url(requests_mock):
+    """
+    The requested URL is the concatenation of
+    the service_base of the RESTApiJWTClient instance and
+    the relative URL passed to RESTApiJWTClient.get().
+    """
+    requests_mock.post(ANY)
     c = RESTApiJWTClient('http://example.com/service/uri_base/')
     response = c.post('post/example', json_data={'pay': 'load'})
     assert response.request.url == 'http://example.com/service/uri_base/post/example'
+
+
+def test_post_specifies_body_content_type(requests_mock):
+    requests_mock.post(ANY)
+    c = RESTApiJWTClient('http://example.com/service/uri_base/')
+    response = c.post('post/example', json_data={'pay': 'load'})
     assert response.request.headers['Content-Type'] == 'application/json; charset=UTF-8'
+
+
+def test_post_sends_payload_as_json_body(requests_mock):
+    requests_mock.post(ANY)
+    c = RESTApiJWTClient('http://example.com/service/uri_base/')
+    response = c.post('post/example', json_data={'pay': 'load'})
     assert response.request.json() == {'pay': 'load'}
+
+
+def test_post_returns_received_response(requests_mock):
+    requests_mock.post(ANY, json={'some response': 'you posted it'})
+    c = RESTApiJWTClient('http://example.com/service/uri_base/')
+    response = c.post('post/example', json_data={'pay': 'load'})
     assert response.json() == {'some response': 'you posted it'}

--- a/tests/api_client/rest_api_client_test.py
+++ b/tests/api_client/rest_api_client_test.py
@@ -1,10 +1,10 @@
-import requests_mock
+import requests_mock as requests_mock_package
 
 from osmaxx.api_client.API_client import RESTApiJWTClient
 
 
 def test_get_performs_request():
-    with requests_mock.mock() as r_mock:
+    with requests_mock_package.mock() as r_mock:
         r_mock.get(
             # Expected request:
             'http://example.com/service/uri_base/get/example',

--- a/tests/api_client/rest_api_client_test.py
+++ b/tests/api_client/rest_api_client_test.py
@@ -6,7 +6,6 @@ def test_get_performs_request(requests_mock):
     requests_mock.get(
         # Expected request:
         ANY,
-        request_headers={'Content-Type': 'application/json; charset=UTF-8'},
 
         # Response if request matched:
         json={'some response': 'you got it'}
@@ -14,6 +13,7 @@ def test_get_performs_request(requests_mock):
     c = RESTApiJWTClient('http://example.com/service/uri_base/')
     response = c.get('get/example')
     assert response.request.url == 'http://example.com/service/uri_base/get/example'
+    assert response.request.headers['Content-Type'] == 'application/json; charset=UTF-8'
     assert response.json() == {'some response': 'you got it'}
 
 
@@ -21,7 +21,6 @@ def test_post_performs_request(requests_mock):
     requests_mock.post(
         # Expected request:
         ANY,
-        request_headers={'Content-Type': 'application/json; charset=UTF-8'},
 
         # Response if request matched:
         json={'some response': 'you posted it'}
@@ -29,5 +28,6 @@ def test_post_performs_request(requests_mock):
     c = RESTApiJWTClient('http://example.com/service/uri_base/')
     response = c.post('post/example', json_data={'pay': 'load'})
     assert response.request.url == 'http://example.com/service/uri_base/post/example'
+    assert response.request.headers['Content-Type'] == 'application/json; charset=UTF-8'
     assert response.request.json() == {'pay': 'load'}
     assert response.json() == {'some response': 'you posted it'}

--- a/tests/api_client/rest_api_client_test.py
+++ b/tests/api_client/rest_api_client_test.py
@@ -1,0 +1,18 @@
+import requests_mock
+
+from osmaxx.api_client.API_client import RESTApiJWTClient
+
+
+def test_get_performs_request():
+    with requests_mock.mock() as r_mock:
+        r_mock.get(
+            # Expected request:
+            'http://example.com/service/uri_base/get/example',
+            request_headers={'Content-Type': 'application/json; charset=UTF-8'},
+
+            # Response if request matched:
+            json={'some response': 'you got it'}
+        )
+        c = RESTApiJWTClient('http://example.com/service/uri_base/')
+        response = c.get('get/example')
+        assert response.json() == {'some response': 'you got it'}

--- a/tests/api_client/rest_api_client_test.py
+++ b/tests/api_client/rest_api_client_test.py
@@ -3,13 +3,7 @@ from requests_mock import ANY
 
 
 def test_get_performs_request(requests_mock):
-    requests_mock.get(
-        # Expected request:
-        ANY,
-
-        # Response if request matched:
-        json={'some response': 'you got it'}
-    )
+    requests_mock.get(ANY, json={'some response': 'you got it'})
     c = RESTApiJWTClient('http://example.com/service/uri_base/')
     response = c.get('get/example')
     assert response.request.url == 'http://example.com/service/uri_base/get/example'
@@ -18,13 +12,7 @@ def test_get_performs_request(requests_mock):
 
 
 def test_post_performs_request(requests_mock):
-    requests_mock.post(
-        # Expected request:
-        ANY,
-
-        # Response if request matched:
-        json={'some response': 'you posted it'}
-    )
+    requests_mock.post(ANY, json={'some response': 'you posted it'})
     c = RESTApiJWTClient('http://example.com/service/uri_base/')
     response = c.post('post/example', json_data={'pay': 'load'})
     assert response.request.url == 'http://example.com/service/uri_base/post/example'

--- a/tests/api_client/rest_api_client_test.py
+++ b/tests/api_client/rest_api_client_test.py
@@ -13,3 +13,20 @@ def test_get_performs_request(requests_mock):
     c = RESTApiJWTClient('http://example.com/service/uri_base/')
     response = c.get('get/example')
     assert response.json() == {'some response': 'you got it'}
+
+
+def test_post_performs_request(requests_mock):
+    def json_callback(request, context):
+        assert request.json() == {'pay': 'load'}
+        return {'some response': 'you posted it'}
+    requests_mock.post(
+        # Expected request:
+        'http://example.com/service/uri_base/post/example',
+        request_headers={'Content-Type': 'application/json; charset=UTF-8'},
+
+        # Response if request matched:
+        json=json_callback
+    )
+    c = RESTApiJWTClient('http://example.com/service/uri_base/')
+    response = c.post('post/example', json_data={'pay': 'load'})
+    assert response.json() == {'some response': 'you posted it'}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -169,6 +169,13 @@ def pytest_configure():
 
 # if any global fixtures are needed, add them below
 
+@pytest.yield_fixture
+def requests_mock():
+    import requests_mock
+    with requests_mock.mock() as m:
+        yield m
+
+
 @pytest.fixture
 def authenticated_client(client):
     """


### PR DESCRIPTION
Not sure whether 92f417d really is an improvement. (Maybe there was more severe duplication back when #343 was filed?) But I guess the tests are worth keeping, so if we don't want 92f417d, I'd suggest to still [merge branch `add_rest_api_client_unit_tests`](https://github.com/geometalab/osmaxx-frontend/compare/combine_repos...add_rest_api_client_unit_tests?expand=1).

#### Reviewed by:
- [x] @hixi
- [ ] @beneditatan