### PR TITLE
Feature/#406 conversion API client reimplementation: create_boundary

### DIFF
--- a/osmaxx/api_client/conversion_api_client.py
+++ b/osmaxx/api_client/conversion_api_client.py
@@ -35,7 +35,7 @@ class ConversionApiClient(JWTClient):
             password=PASSWORD,
         )
 
-    def create_boundary(self, multipolygon):
+    def create_boundary(self, multipolygon, *, name):
         geo_json = json.loads(multipolygon.json)
         json_payload = dict(name='HSR Testcut', clipping_multi_polygon=geo_json)
         self.authorized_post(url='clipping_area/', json_data=json_payload)

--- a/osmaxx/api_client/conversion_api_client.py
+++ b/osmaxx/api_client/conversion_api_client.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from collections import OrderedDict
 
@@ -34,8 +35,10 @@ class ConversionApiClient(JWTClient):
             password=PASSWORD,
         )
 
-    def create_boundary(self, _):
-        self.authorized_post(url='clipping_area/', json_data='')
+    def create_boundary(self, multipolygon):
+        geo_json = json.loads(multipolygon.json)
+        json_payload = dict(name='HSR Testcut', clipping_multi_polygon=geo_json)
+        self.authorized_post(url='clipping_area/', json_data=json_payload)
 
     @staticmethod
     def _extraction_processing_overdue(progress, extraction_order):

--- a/osmaxx/api_client/conversion_api_client.py
+++ b/osmaxx/api_client/conversion_api_client.py
@@ -34,6 +34,9 @@ class ConversionApiClient(JWTClient):
             password=PASSWORD,
         )
 
+    def create_boundary(self, _):
+        self.authorized_post(url='clipping_area/', json_data='')
+
     @staticmethod
     def _extraction_processing_overdue(progress, extraction_order):
         if extraction_order.process_start_time is None:

--- a/osmaxx/api_client/conversion_api_client.py
+++ b/osmaxx/api_client/conversion_api_client.py
@@ -37,7 +37,7 @@ class ConversionApiClient(JWTClient):
 
     def create_boundary(self, multipolygon, *, name):
         geo_json = json.loads(multipolygon.json)
-        json_payload = dict(name='HSR Testcut', clipping_multi_polygon=geo_json)
+        json_payload = dict(name=name, clipping_multi_polygon=geo_json)
         self.authorized_post(url='clipping_area/', json_data=json_payload)
 
     @staticmethod

--- a/osmaxx/excerptexport/models/bounding_geometry.py
+++ b/osmaxx/excerptexport/models/bounding_geometry.py
@@ -95,8 +95,7 @@ class BBoxBoundingGeometry(AdminUrlModelMixin, BoundingGeometry):
             GEOSGeometry('POINT(%s %s)' % (self.east, self.south)),
             self.south_west
         ])
-        multipolygon = MultiPolygon(polygon)
-        return multipolygon
+        return MultiPolygon(polygon)
 
     @staticmethod
     def create_from_bounding_box_coordinates(north, east, south, west):

--- a/osmaxx/excerptexport/models/bounding_geometry.py
+++ b/osmaxx/excerptexport/models/bounding_geometry.py
@@ -9,11 +9,6 @@ from osmaxx.utilities.model_mixins import AdminUrlModelMixin
 
 
 class BoundingGeometry(models.Model):
-    def send_to_conversion_service(self):
-        from osmaxx.api_client.conversion_api_client import ConversionApiClient
-        api_client = ConversionApiClient()
-        return api_client.create_boundary(self.geometry)
-
     @property
     def type(self):
         return type(self).__name__

--- a/osmaxx/excerptexport/models/bounding_geometry.py
+++ b/osmaxx/excerptexport/models/bounding_geometry.py
@@ -12,7 +12,7 @@ class BoundingGeometry(models.Model):
     def send_to_conversion_service(self):
         from osmaxx.api_client.conversion_api_client import ConversionApiClient
         api_client = ConversionApiClient()
-        api_client.create_boundary(self.geometry)
+        return api_client.create_boundary(self.geometry)
 
     @property
     def type(self):

--- a/osmaxx/excerptexport/models/bounding_geometry.py
+++ b/osmaxx/excerptexport/models/bounding_geometry.py
@@ -96,7 +96,7 @@ class BBoxBoundingGeometry(AdminUrlModelMixin, BoundingGeometry):
             self.south_west
         ])
         multipolygon = MultiPolygon(polygon)
-        return GEOSGeometry(multipolygon)
+        return multipolygon
 
     @staticmethod
     def create_from_bounding_box_coordinates(north, east, south, west):

--- a/osmaxx/excerptexport/models/bounding_geometry.py
+++ b/osmaxx/excerptexport/models/bounding_geometry.py
@@ -1,5 +1,5 @@
 from django.contrib.gis.db import models
-from django.contrib.gis.geos import GEOSGeometry, Polygon
+from django.contrib.gis.geos import GEOSGeometry, MultiPolygon, Polygon
 
 from model_utils.managers import InheritanceManager
 
@@ -95,7 +95,8 @@ class BBoxBoundingGeometry(AdminUrlModelMixin, BoundingGeometry):
             GEOSGeometry('POINT(%s %s)' % (self.east, self.south)),
             self.south_west
         ])
-        return GEOSGeometry(polygon)
+        multipolygon = MultiPolygon(polygon)
+        return GEOSGeometry(multipolygon)
 
     @staticmethod
     def create_from_bounding_box_coordinates(north, east, south, west):

--- a/osmaxx/excerptexport/models/bounding_geometry.py
+++ b/osmaxx/excerptexport/models/bounding_geometry.py
@@ -9,6 +9,11 @@ from osmaxx.utilities.model_mixins import AdminUrlModelMixin
 
 
 class BoundingGeometry(models.Model):
+    def send_to_conversion_service(self):
+        from osmaxx.api_client.conversion_api_client import ConversionApiClient
+        api_client = ConversionApiClient()
+        api_client.create_boundary(self.geometry)
+
     @property
     def type(self):
         return type(self).__name__

--- a/osmaxx/excerptexport/models/bounding_geometry.py
+++ b/osmaxx/excerptexport/models/bounding_geometry.py
@@ -88,13 +88,7 @@ class BBoxBoundingGeometry(AdminUrlModelMixin, BoundingGeometry):
 
     @property
     def geometry(self):
-        polygon = Polygon([
-            self.south_west,
-            GEOSGeometry('POINT(%s %s)' % (self.west, self.north)),
-            self.north_east,
-            GEOSGeometry('POINT(%s %s)' % (self.east, self.south)),
-            self.south_west
-        ])
+        polygon = Polygon.from_bbox((self.west, self.south, self.east, self.north))
         return MultiPolygon(polygon)
 
     @staticmethod

--- a/osmaxx/excerptexport/models/excerpt.py
+++ b/osmaxx/excerptexport/models/excerpt.py
@@ -11,6 +11,11 @@ class Excerpt(models.Model):
     owner = models.ForeignKey(User, related_name='excerpts', verbose_name=_('owner'))
     bounding_geometry = models.OneToOneField('BoundingGeometry', verbose_name=_('bounding geometry'))
 
+    def send_to_conversion_service(self):
+        from osmaxx.api_client.conversion_api_client import ConversionApiClient
+        api_client = ConversionApiClient()
+        return api_client.create_boundary(self.bounding_geometry.geometry)
+
     @property
     def type_of_geometry(self):
         return self.bounding_geometry.type_of_geometry

--- a/osmaxx/excerptexport/models/excerpt.py
+++ b/osmaxx/excerptexport/models/excerpt.py
@@ -14,7 +14,7 @@ class Excerpt(models.Model):
     def send_to_conversion_service(self):
         from osmaxx.api_client.conversion_api_client import ConversionApiClient
         api_client = ConversionApiClient()
-        return api_client.create_boundary(self.bounding_geometry.geometry)
+        return api_client.create_boundary(self.bounding_geometry.geometry, name=self.name)
 
     @property
     def type_of_geometry(self):

--- a/osmaxx/excerptexport/models/extraction_order.py
+++ b/osmaxx/excerptexport/models/extraction_order.py
@@ -61,7 +61,12 @@ class ExtractionOrder(models.Model):
     )
 
     def forward_to_conversion_service(self):
-        self.excerpt.bounding_geometry.send_to_conversion_service()
+        from osmaxx.api_client.conversion_api_client import ConversionApiClient
+        clipping_area_json = self.excerpt.bounding_geometry.send_to_conversion_service()
+        gis_options = self.extraction_configuration['gis_options']
+        api_client = ConversionApiClient()
+        for extraction_format in self.extraction_formats:
+            api_client.create_parametrization(clipping_area_json, extraction_format, gis_options)
 
     def __str__(self):
         return ', '.join(
@@ -120,7 +125,7 @@ class ExtractionOrder(models.Model):
 
     @property
     def extraction_formats(self):
-        return json.loads(self.extraction_configuration).get('gis_formats', None)
+        return self.extraction_configuration.get('gis_formats', None)
 
     @property
     def process_due_time(self):

--- a/osmaxx/excerptexport/models/extraction_order.py
+++ b/osmaxx/excerptexport/models/extraction_order.py
@@ -60,6 +60,9 @@ class ExtractionOrder(models.Model):
         default=DOWNLOAD_STATUS_NOT_DOWNLOADED
     )
 
+    def forward_to_conversion_service(self):
+        pass
+
     def __str__(self):
         return ', '.join(
             [

--- a/osmaxx/excerptexport/models/extraction_order.py
+++ b/osmaxx/excerptexport/models/extraction_order.py
@@ -61,7 +61,7 @@ class ExtractionOrder(models.Model):
     )
 
     def forward_to_conversion_service(self):
-        pass
+        self.excerpt.bounding_geometry.send_to_conversion_service()
 
     def __str__(self):
         return ', '.join(

--- a/osmaxx/excerptexport/models/extraction_order.py
+++ b/osmaxx/excerptexport/models/extraction_order.py
@@ -60,13 +60,14 @@ class ExtractionOrder(models.Model):
         default=DOWNLOAD_STATUS_NOT_DOWNLOADED
     )
 
-    def forward_to_conversion_service(self):
+    def forward_to_conversion_service(self, *, incoming_request):
         from osmaxx.api_client.conversion_api_client import ConversionApiClient
         clipping_area_json = self.excerpt.bounding_geometry.send_to_conversion_service()
         gis_options = self.extraction_configuration['gis_options']
         api_client = ConversionApiClient()
         for extraction_format in self.extraction_formats:
-            api_client.create_parametrization(clipping_area_json, extraction_format, gis_options)
+            parametrization_json = api_client.create_parametrization(clipping_area_json, extraction_format, gis_options)
+            api_client.create_job(parametrization_json, incoming_request)
 
     def __str__(self):
         return ', '.join(

--- a/osmaxx/excerptexport/models/extraction_order.py
+++ b/osmaxx/excerptexport/models/extraction_order.py
@@ -62,7 +62,7 @@ class ExtractionOrder(models.Model):
 
     def forward_to_conversion_service(self, *, incoming_request):
         from osmaxx.api_client.conversion_api_client import ConversionApiClient
-        clipping_area_json = self.excerpt.bounding_geometry.send_to_conversion_service()
+        clipping_area_json = self.excerpt.send_to_conversion_service()
         gis_options = self.extraction_configuration['gis_options']
         api_client = ConversionApiClient()
         jobs_json = []

--- a/osmaxx/excerptexport/models/extraction_order.py
+++ b/osmaxx/excerptexport/models/extraction_order.py
@@ -65,9 +65,12 @@ class ExtractionOrder(models.Model):
         clipping_area_json = self.excerpt.bounding_geometry.send_to_conversion_service()
         gis_options = self.extraction_configuration['gis_options']
         api_client = ConversionApiClient()
+        jobs_json = []
         for extraction_format in self.extraction_formats:
             parametrization_json = api_client.create_parametrization(clipping_area_json, extraction_format, gis_options)
-            api_client.create_job(parametrization_json, incoming_request)
+            job_json = api_client.create_job(parametrization_json, incoming_request)
+            jobs_json.append(job_json)
+        return jobs_json
 
     def __str__(self):
         return ', '.join(

--- a/tests/api_client/conversion_api_client_test.py
+++ b/tests/api_client/conversion_api_client_test.py
@@ -5,6 +5,18 @@ from django.contrib.gis.gdal.geometries import MultiPolygon
 from osmaxx.api_client.conversion_api_client import ConversionApiClient
 
 
+def test_create_boundary_makes_authorized_post_with_json_payload(mocker):
+    c = ConversionApiClient()
+    geos_multipolygon = MultiPolygon(
+        'MULTIPOLYGON (((5 0, 5 1, 6 1, 5 0)),'
+        '((1 1, 4 0, -3 -3, 0 4, 1 1),'
+        '(0 0, 3 0, -2 -2, 0 3, 0 0)))'
+    )
+    mocker.patch.object(c, 'authorized_post', autospec=True)
+    c.create_boundary(geos_multipolygon)
+    c.authorized_post.assert_called_once_with(url=ANY, json_data=ANY)
+
+
 def test_create_boundary_posts_to_clipping_area_resource(mocker):
     c = ConversionApiClient()
     geos_multipolygon = MultiPolygon(
@@ -14,4 +26,5 @@ def test_create_boundary_posts_to_clipping_area_resource(mocker):
     )
     mocker.patch.object(c, 'authorized_post', autospec=True)
     c.create_boundary(geos_multipolygon)
-    c.authorized_post.assert_called_with(url='clipping_area/', json_data=ANY)
+    args, kwargs = c.authorized_post.call_args
+    assert kwargs['url'] == 'clipping_area/'

--- a/tests/api_client/conversion_api_client_test.py
+++ b/tests/api_client/conversion_api_client_test.py
@@ -10,14 +10,14 @@ from osmaxx.api_client.conversion_api_client import ConversionApiClient
 def test_create_boundary_makes_authorized_post_with_json_payload(mocker, geos_multipolygon):
     c = ConversionApiClient()
     mocker.patch.object(c, 'authorized_post', autospec=True)
-    c.create_boundary(geos_multipolygon)
+    c.create_boundary(geos_multipolygon, name='')
     c.authorized_post.assert_called_once_with(url=ANY, json_data=ANY)
 
 
 def test_create_boundary_posts_to_clipping_area_resource(mocker, geos_multipolygon):
     c = ConversionApiClient()
     mocker.patch.object(c, 'authorized_post', autospec=True)
-    c.create_boundary(geos_multipolygon)
+    c.create_boundary(geos_multipolygon, name='')
     args, kwargs = c.authorized_post.call_args
     assert kwargs['url'] == 'clipping_area/'
 
@@ -25,7 +25,7 @@ def test_create_boundary_posts_to_clipping_area_resource(mocker, geos_multipolyg
 def test_create_boundary_posts_geojson(mocker, geos_multipolygon):
     c = ConversionApiClient()
     mocker.patch.object(c, 'authorized_post', autospec=True)
-    c.create_boundary(geos_multipolygon)
+    c.create_boundary(geos_multipolygon, name='')
     args, kwargs = c.authorized_post.call_args
     assert kwargs['json_data'] == {
         "name": "HSR Testcut",

--- a/tests/api_client/conversion_api_client_test.py
+++ b/tests/api_client/conversion_api_client_test.py
@@ -1,30 +1,30 @@
 from unittest.mock import ANY
 
+import pytest
 from django.contrib.gis.gdal.geometries import MultiPolygon
 
 from osmaxx.api_client.conversion_api_client import ConversionApiClient
 
 
-def test_create_boundary_makes_authorized_post_with_json_payload(mocker):
+def test_create_boundary_makes_authorized_post_with_json_payload(mocker, geos_multipolygon):
     c = ConversionApiClient()
-    geos_multipolygon = MultiPolygon(
-        'MULTIPOLYGON (((5 0, 5 1, 6 1, 5 0)),'
-        '((1 1, 4 0, -3 -3, 0 4, 1 1),'
-        '(0 0, 3 0, -2 -2, 0 3, 0 0)))'
-    )
     mocker.patch.object(c, 'authorized_post', autospec=True)
     c.create_boundary(geos_multipolygon)
     c.authorized_post.assert_called_once_with(url=ANY, json_data=ANY)
 
 
-def test_create_boundary_posts_to_clipping_area_resource(mocker):
+def test_create_boundary_posts_to_clipping_area_resource(mocker, geos_multipolygon):
     c = ConversionApiClient()
-    geos_multipolygon = MultiPolygon(
-        'MULTIPOLYGON (((5 0, 5 1, 6 1, 5 0)),'
-        '((1 1, 4 0, -3 -3, 0 4, 1 1),'
-        '(0 0, 3 0, -2 -2, 0 3, 0 0)))'
-    )
     mocker.patch.object(c, 'authorized_post', autospec=True)
     c.create_boundary(geos_multipolygon)
     args, kwargs = c.authorized_post.call_args
     assert kwargs['url'] == 'clipping_area/'
+
+
+@pytest.fixture
+def geos_multipolygon():
+    return MultiPolygon(
+        'MULTIPOLYGON (((5 0, 5 1, 6 1, 5 0)),'
+        '((1 1, 4 0, -3 -3, 0 4, 1 1),'
+        '(0 0, 3 0, -2 -2, 0 3, 0 0)))'
+    )

--- a/tests/api_client/conversion_api_client_test.py
+++ b/tests/api_client/conversion_api_client_test.py
@@ -1,5 +1,5 @@
 import json
-from unittest.mock import ANY
+from unittest.mock import ANY, sentinel
 
 import pytest
 from django.contrib.gis.gdal.geometries import MultiPolygon
@@ -10,14 +10,14 @@ from osmaxx.api_client.conversion_api_client import ConversionApiClient
 def test_create_boundary_makes_authorized_post_with_json_payload(mocker, geos_multipolygon):
     c = ConversionApiClient()
     mocker.patch.object(c, 'authorized_post', autospec=True)
-    c.create_boundary(geos_multipolygon, name='')
+    c.create_boundary(geos_multipolygon, name=sentinel.NAME)
     c.authorized_post.assert_called_once_with(url=ANY, json_data=ANY)
 
 
 def test_create_boundary_posts_to_clipping_area_resource(mocker, geos_multipolygon):
     c = ConversionApiClient()
     mocker.patch.object(c, 'authorized_post', autospec=True)
-    c.create_boundary(geos_multipolygon, name='')
+    c.create_boundary(geos_multipolygon, name=sentinel.NAME)
     args, kwargs = c.authorized_post.call_args
     assert kwargs['url'] == 'clipping_area/'
 
@@ -25,10 +25,10 @@ def test_create_boundary_posts_to_clipping_area_resource(mocker, geos_multipolyg
 def test_create_boundary_posts_geojson(mocker, geos_multipolygon):
     c = ConversionApiClient()
     mocker.patch.object(c, 'authorized_post', autospec=True)
-    c.create_boundary(geos_multipolygon, name='')
+    c.create_boundary(geos_multipolygon, name=sentinel.NAME)
     args, kwargs = c.authorized_post.call_args
     assert kwargs['json_data'] == {
-        "name": "HSR Testcut",
+        "name": sentinel.NAME,
         "clipping_multi_polygon": {
             "type": "MultiPolygon",
             "coordinates": nested_list(geos_multipolygon.coords)

--- a/tests/api_client/conversion_api_client_test.py
+++ b/tests/api_client/conversion_api_client_test.py
@@ -31,7 +31,7 @@ def test_create_boundary_posts_geojson(mocker, geos_multipolygon):
         "name": "HSR Testcut",
         "clipping_multi_polygon": {
             "type": "MultiPolygon",
-            "coordinates": json.loads(json.dumps(geos_multipolygon.coords))
+            "coordinates": nested_list(geos_multipolygon.coords)
         }
     }
 
@@ -43,3 +43,22 @@ def geos_multipolygon():
         '((1 1, 4 0, -3 -3, 0 4, 1 1),'
         '(0 0, 3 0, -2 -2, 0 3, 0 0)))'
     )
+
+
+def nested_list(nested_collection):
+    """
+    Turn nested collection to nested list.
+
+    Might contain copies of leaf elements instead of references to the original ones.
+
+    Args:
+        nested_collection: a nested collection
+
+    Returns:
+        nested list with the same structure and content as nested_collection
+    """
+    # For alternatives, see http://stackoverflow.com/questions/1014352/
+
+    # (Ab)use the fact that json.loads always produces Python lists for JSON lists,
+    # while json.dumps turns any Python collection into a JSON list:
+    return json.loads(json.dumps(nested_collection))

--- a/tests/api_client/conversion_api_client_test.py
+++ b/tests/api_client/conversion_api_client_test.py
@@ -1,0 +1,17 @@
+from unittest.mock import ANY
+
+from django.contrib.gis.gdal.geometries import MultiPolygon
+
+from osmaxx.api_client.conversion_api_client import ConversionApiClient
+
+
+def test_create_boundary_posts_to_clipping_area_resource(mocker):
+    c = ConversionApiClient()
+    geos_multipolygon = MultiPolygon(
+        'MULTIPOLYGON (((5 0, 5 1, 6 1, 5 0)),'
+        '((1 1, 4 0, -3 -3, 0 4, 1 1),'
+        '(0 0, 3 0, -2 -2, 0 3, 0 0)))'
+    )
+    mocker.patch.object(c, 'authorized_post', autospec=True)
+    c.create_boundary(geos_multipolygon)
+    c.authorized_post.assert_called_with(url='clipping_area/', json_data=ANY)

--- a/tests/api_client/conversion_api_client_test.py
+++ b/tests/api_client/conversion_api_client_test.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import ANY
 
 import pytest
@@ -30,15 +31,7 @@ def test_create_boundary_posts_geojson(mocker, geos_multipolygon):
         "name": "HSR Testcut",
         "clipping_multi_polygon": {
             "type": "MultiPolygon",
-            "coordinates": [
-                [
-                    [[5, 0], [5, 1], [6, 1], [5, 0]],
-                ],
-                [
-                    [[1, 1], [4, 0], [-3, -3], [0, 4], [1, 1]],
-                    [[0, 0], [3, 0], [-2, -2], [0, 3], [0, 0]],
-                ],
-            ],
+            "coordinates": json.loads(json.dumps(geos_multipolygon.coords))
         }
     }
 

--- a/tests/api_client/conversion_api_client_test.py
+++ b/tests/api_client/conversion_api_client_test.py
@@ -21,6 +21,28 @@ def test_create_boundary_posts_to_clipping_area_resource(mocker, geos_multipolyg
     assert kwargs['url'] == 'clipping_area/'
 
 
+def test_create_boundary_posts_geojson(mocker, geos_multipolygon):
+    c = ConversionApiClient()
+    mocker.patch.object(c, 'authorized_post', autospec=True)
+    c.create_boundary(geos_multipolygon)
+    args, kwargs = c.authorized_post.call_args
+    assert kwargs['json_data'] == {
+        "name": "HSR Testcut",
+        "clipping_multi_polygon": {
+            "type": "MultiPolygon",
+            "coordinates": [
+                [
+                    [[5, 0], [5, 1], [6, 1], [5, 0]],
+                ],
+                [
+                    [[1, 1], [4, 0], [-3, -3], [0, 4], [1, 1]],
+                    [[0, 0], [3, 0], [-2, -2], [0, 3], [0, 0]],
+                ],
+            ],
+        }
+    }
+
+
 @pytest.fixture
 def geos_multipolygon():
     return MultiPolygon(

--- a/tests/excerptexport/test_conversion_api_client.py
+++ b/tests/excerptexport/test_conversion_api_client.py
@@ -1,4 +1,5 @@
 import time
+from unittest import mock
 from unittest.mock import Mock
 from urllib.parse import urlparse
 
@@ -65,8 +66,10 @@ class ConversionApiClientTestCase(TestCase):
     #
     # Unit tests:
 
-    def test_create_jobs(self):
+    @mock.patch.object(ConversionApiClient, 'create_boundary', create=True)  # TODO: remove 'create' once implemented
+    def test_create_jobs(self, create_boundary_mock):
         self.extraction_order.forward_to_conversion_service()
+        create_boundary_mock.assert_called_once_with(self.bounding_box.geometry)
 
     #
     # Integration tests:

--- a/tests/excerptexport/test_conversion_api_client.py
+++ b/tests/excerptexport/test_conversion_api_client.py
@@ -7,9 +7,7 @@ import os
 from django.contrib.auth.models import User
 from django.core.urlresolvers import resolve
 from django.test.testcases import TestCase
-from hamcrest import matches_regexp, match_equality
-from hamcrest.core.assert_that import assert_that
-from hamcrest.library.collection.issequence_containinginanyorder import contains_inanyorder
+from hamcrest import assert_that, contains_inanyorder, matches_regexp, match_equality
 
 from osmaxx.api_client import ConversionApiClient
 from osmaxx.excerptexport.models import Excerpt, ExtractionOrder, ExtractionOrderState, BBoxBoundingGeometry

--- a/tests/excerptexport/test_conversion_api_client.py
+++ b/tests/excerptexport/test_conversion_api_client.py
@@ -78,7 +78,7 @@ class ConversionApiClientTestCase(TestCase):
         create=True,  # TODO: remove 'create' once implemented
         side_effect=[sentinel.parametrization_1, sentinel.parametrization_2],
     )
-    @mock.patch.object(ConversionApiClient, 'create_boundary', create=True)  # TODO: remove 'create' once implemented
+    @mock.patch.object(ConversionApiClient, 'create_boundary')
     def test_extraction_order_forward_to_conversion_service(
             self, create_boundary_mock, create_parametrization_mock, create_job_mock):
         result = self.extraction_order.forward_to_conversion_service(incoming_request=self.request)

--- a/tests/excerptexport/test_conversion_api_client.py
+++ b/tests/excerptexport/test_conversion_api_client.py
@@ -62,6 +62,17 @@ class ConversionApiClientTestCase(TestCase):
         }
         self.api_client = ConversionApiClient()
 
+    #
+    # Unit tests:
+
+    def test_create_jobs(self):
+        self.extraction_order.forward_to_conversion_service()
+
+    #
+    # Integration tests:
+
+    # TODO: re-record VCR (service API has changed)
+
     @vcr.use_cassette('fixtures/vcr/conversion_api-test_create_job.yml')
     def test_create_job(self):
         self.api_client.login()

--- a/tests/excerptexport/test_conversion_api_client.py
+++ b/tests/excerptexport/test_conversion_api_client.py
@@ -1,6 +1,6 @@
 import time
 from unittest import mock
-from unittest.mock import Mock
+from unittest.mock import Mock, sentinel
 from urllib.parse import urlparse
 
 import os
@@ -69,7 +69,11 @@ class ConversionApiClientTestCase(TestCase):
     # Unit tests:
 
     @mock.patch.object(ConversionApiClient, 'create_job')
-    @mock.patch.object(ConversionApiClient, 'create_parametrization', create=True)  # TODO: remove 'create' once implemented
+    @mock.patch.object(
+        ConversionApiClient, 'create_parametrization',
+        create=True,  # TODO: remove 'create' once implemented
+        side_effect=[sentinel.parametrization_1, sentinel.parametrization_2],
+    )
     @mock.patch.object(ConversionApiClient, 'create_boundary', create=True)  # TODO: remove 'create' once implemented
     def test_extraction_order_forward_to_conversion_service(
             self, create_boundary_mock, create_parametrization_mock, create_job_mock):
@@ -85,8 +89,8 @@ class ConversionApiClientTestCase(TestCase):
         )
         assert_that(
             create_job_mock.mock_calls, contains_inanyorder(
-                mock.call(create_parametrization_mock.return_value, self.request),
-                mock.call(create_parametrization_mock.return_value, self.request),
+                mock.call(sentinel.parametrization_1, self.request),
+                mock.call(sentinel.parametrization_2, self.request),
             )
         )
 

--- a/tests/excerptexport/test_conversion_api_client.py
+++ b/tests/excerptexport/test_conversion_api_client.py
@@ -66,7 +66,7 @@ class ConversionApiClientTestCase(TestCase):
     #
     # Unit tests:
 
-    @mock.patch.object(ConversionApiClient, 'create_job')
+    @mock.patch.object(ConversionApiClient, 'create_job', side_effect=[sentinel.job_1, sentinel.job_2])
     @mock.patch.object(
         ConversionApiClient, 'create_parametrization',
         create=True,  # TODO: remove 'create' once implemented
@@ -75,7 +75,7 @@ class ConversionApiClientTestCase(TestCase):
     @mock.patch.object(ConversionApiClient, 'create_boundary', create=True)  # TODO: remove 'create' once implemented
     def test_extraction_order_forward_to_conversion_service(
             self, create_boundary_mock, create_parametrization_mock, create_job_mock):
-        self.extraction_order.forward_to_conversion_service(incoming_request=self.request)
+        result = self.extraction_order.forward_to_conversion_service(incoming_request=self.request)
 
         create_boundary_mock.assert_called_once_with(self.bounding_box.geometry)
         gis_conversion_options = self.extraction_order.extraction_configuration['gis_options']
@@ -89,6 +89,12 @@ class ConversionApiClientTestCase(TestCase):
             create_job_mock.mock_calls, contains_inanyorder(
                 mock.call(sentinel.parametrization_1, self.request),
                 mock.call(sentinel.parametrization_2, self.request),
+            )
+        )
+        assert_that(
+            result, contains_inanyorder(
+                sentinel.job_1,
+                sentinel.job_2,
             )
         )
 

--- a/tests/excerptexport/test_conversion_api_client.py
+++ b/tests/excerptexport/test_conversion_api_client.py
@@ -83,7 +83,7 @@ class ConversionApiClientTestCase(TestCase):
             self, create_boundary_mock, create_parametrization_mock, create_job_mock):
         result = self.extraction_order.forward_to_conversion_service(incoming_request=self.request)
 
-        create_boundary_mock.assert_called_once_with(self.bounding_box.geometry)
+        create_boundary_mock.assert_called_once_with(self.bounding_box.geometry, name=self.excerpt.name)
         gis_conversion_options = self.extraction_order.extraction_configuration['gis_options']
         assert_that(
             create_parametrization_mock.mock_calls, contains_inanyorder(

--- a/tests/excerptexport/test_models.py
+++ b/tests/excerptexport/test_models.py
@@ -1,5 +1,6 @@
 import json
 
+from django.contrib.gis.geos import Polygon
 from django.test.testcases import TestCase
 from django.contrib.auth.models import User
 from django.core.files.uploadedfile import SimpleUploadedFile
@@ -13,38 +14,43 @@ class BBoxBoundingGeometryTestCase(TestCase):
         BBoxBoundingGeometry.create_from_bounding_box_coordinates(1.1, 2.2, 3.3, 4.4)
         self.assertEqual(BoundingGeometry.objects.count(), 1)
 
+    def test_geometry_is_collection_containing_one_polygon(self):
+        BBoxBoundingGeometry.create_from_bounding_box_coordinates(1.1, 2.2, 3.3, 4.4)
+        self.assertEquals(len(BoundingGeometry.objects.first().bboxboundinggeometry.geometry), 1)
+        self.assertIsInstance(BoundingGeometry.objects.first().bboxboundinggeometry.geometry[0], Polygon)
+
     def test_geometry_has_only_exterior_ring(self):
         BBoxBoundingGeometry.create_from_bounding_box_coordinates(1.1, 2.2, 3.3, 4.4)
-        self.assertEqual(BoundingGeometry.objects.first().bboxboundinggeometry.geometry.num_interior_rings, 0)
+        self.assertEqual(BoundingGeometry.objects.first().bboxboundinggeometry.geometry[0].num_interior_rings, 0)
 
     def test_geometry_has_exterior_ring_with_5_points(self):
         BBoxBoundingGeometry.create_from_bounding_box_coordinates(1.1, 2.2, 3.3, 4.4)
-        self.assertEqual(BoundingGeometry.objects.first().bboxboundinggeometry.geometry.exterior_ring.num_points, 5)
+        self.assertEqual(BoundingGeometry.objects.first().bboxboundinggeometry.geometry[0].exterior_ring.num_points, 5)
 
     def test_geometry_has_closed_exterior_ring(self):
         BBoxBoundingGeometry.create_from_bounding_box_coordinates(1.1, 2.2, 3.3, 4.4)
-        exterior_ring = BoundingGeometry.objects.first().bboxboundinggeometry.geometry.exterior_ring
+        exterior_ring = BoundingGeometry.objects.first().bboxboundinggeometry.geometry[0].exterior_ring
         self.assertEqual(exterior_ring[0], exterior_ring[-1])
 
     def test_geometry_contains_north_east_corner(self):
         BBoxBoundingGeometry.create_from_bounding_box_coordinates(1.1, 2.2, 3.3, 4.4)
-        self.assertIn((2.2, 1.1), BoundingGeometry.objects.first().bboxboundinggeometry.geometry.exterior_ring)
+        self.assertIn((2.2, 1.1), BoundingGeometry.objects.first().bboxboundinggeometry.geometry[0].exterior_ring)
 
     def test_geometry_contains_south_east_corner(self):
         BBoxBoundingGeometry.create_from_bounding_box_coordinates(1.1, 2.2, 3.3, 4.4)
-        self.assertIn((2.2, 3.3), BoundingGeometry.objects.first().bboxboundinggeometry.geometry.exterior_ring)
+        self.assertIn((2.2, 3.3), BoundingGeometry.objects.first().bboxboundinggeometry.geometry[0].exterior_ring)
 
     def test_geometry_contains_north_west_corner(self):
         BBoxBoundingGeometry.create_from_bounding_box_coordinates(1.1, 2.2, 3.3, 4.4)
-        self.assertIn((4.4, 1.1), BoundingGeometry.objects.first().bboxboundinggeometry.geometry.exterior_ring)
+        self.assertIn((4.4, 1.1), BoundingGeometry.objects.first().bboxboundinggeometry.geometry[0].exterior_ring)
 
     def test_geometry_contains_south_west_corner(self):
         BBoxBoundingGeometry.create_from_bounding_box_coordinates(1.1, 2.2, 3.3, 4.4)
-        self.assertIn((4.4, 3.3), BoundingGeometry.objects.first().bboxboundinggeometry.geometry.exterior_ring)
+        self.assertIn((4.4, 3.3), BoundingGeometry.objects.first().bboxboundinggeometry.geometry[0].exterior_ring)
 
     def test_geometry_has_clockwise_exterior_ring_starting_at_south_west(self):
         BBoxBoundingGeometry.create_from_bounding_box_coordinates(1.1, 2.2, 3.3, 4.4)
-        self.assertEqual(BoundingGeometry.objects.first().bboxboundinggeometry.geometry.exterior_ring[:],
+        self.assertEqual(BoundingGeometry.objects.first().bboxboundinggeometry.geometry[0].exterior_ring[:],
                          [(4.4, 3.3), (4.4, 1.1), (2.2, 1.1), (2.2, 3.3), (4.4, 3.3)])
 
 


### PR DESCRIPTION
connected to #406 (implements part of it)

#### Implements
* `ExtractionOrder.forward_to_conversion_service(...)`
* `ConversionApiClient.create_boundary(...)`

#### Still to be implemented
(already being used by implementation of `ExtractionOrder.forward_to_conversion_service(...)`):
* `ConversionApiClient.create_parametrization(...)`
* `ConversionApiClient.api_client.create_job(...)`

### Reviewed by
- [x] @hixi
- [ ] @beneditatan