### PR TITLE
Feature/#406 conversion API client reimplementation: create_parametrization()

### DIFF
--- a/osmaxx/api_client/conversion_api_client.py
+++ b/osmaxx/api_client/conversion_api_client.py
@@ -41,7 +41,17 @@ class ConversionApiClient(JWTClient):
         return self.authorized_post(url='clipping_area/', json_data=json_payload)
 
     def create_parametrization(self, *, boundary, out_format, out_srs):
-        json_payload = dict(clipping_area=None, out_format=None, out_srs=None)
+        """
+
+        Args:
+            boundary: A dictionary as returned by create_boundary
+            out_format:
+            out_srs:
+
+        Returns:
+
+        """
+        json_payload = dict(clipping_area=boundary['id'], out_format=None, out_srs=None)
         return self.authorized_post(url='conversion_parametrization/', json_data=json_payload)
 
     @staticmethod

--- a/osmaxx/api_client/conversion_api_client.py
+++ b/osmaxx/api_client/conversion_api_client.py
@@ -40,6 +40,9 @@ class ConversionApiClient(JWTClient):
         json_payload = dict(name=name, clipping_multi_polygon=geo_json)
         return self.authorized_post(url='clipping_area/', json_data=json_payload)
 
+    def create_parametrization(self, *, boundary, out_format, out_srs):
+        self.authorized_post(url=None, json_data=None)
+
     @staticmethod
     def _extraction_processing_overdue(progress, extraction_order):
         if extraction_order.process_start_time is None:

--- a/osmaxx/api_client/conversion_api_client.py
+++ b/osmaxx/api_client/conversion_api_client.py
@@ -46,12 +46,12 @@ class ConversionApiClient(JWTClient):
         Args:
             boundary: A dictionary as returned by create_boundary
             out_format: A string identifying the output format
-            out_srs:
+            out_srs: A string identifying the spatial reference system of the output
 
         Returns:
 
         """
-        json_payload = dict(clipping_area=boundary['id'], out_format=out_format, out_srs=None)
+        json_payload = dict(clipping_area=boundary['id'], out_format=out_format, out_srs=out_srs)
         return self.authorized_post(url='conversion_parametrization/', json_data=json_payload)
 
     @staticmethod

--- a/osmaxx/api_client/conversion_api_client.py
+++ b/osmaxx/api_client/conversion_api_client.py
@@ -42,7 +42,7 @@ class ConversionApiClient(JWTClient):
 
     def create_parametrization(self, *, boundary, out_format, out_srs):
         json_payload = dict(clipping_area=None, out_format=None, out_srs=None)
-        self.authorized_post(url='conversion_parametrization/', json_data=json_payload)
+        return self.authorized_post(url='conversion_parametrization/', json_data=json_payload)
 
     @staticmethod
     def _extraction_processing_overdue(progress, extraction_order):

--- a/osmaxx/api_client/conversion_api_client.py
+++ b/osmaxx/api_client/conversion_api_client.py
@@ -49,7 +49,7 @@ class ConversionApiClient(JWTClient):
             out_srs: A string identifying the spatial reference system of the output
 
         Returns:
-
+            A dictionary representing the payload of the service's response
         """
         json_payload = dict(clipping_area=boundary['id'], out_format=out_format, out_srs=out_srs)
         return self.authorized_post(url='conversion_parametrization/', json_data=json_payload)

--- a/osmaxx/api_client/conversion_api_client.py
+++ b/osmaxx/api_client/conversion_api_client.py
@@ -41,7 +41,8 @@ class ConversionApiClient(JWTClient):
         return self.authorized_post(url='clipping_area/', json_data=json_payload)
 
     def create_parametrization(self, *, boundary, out_format, out_srs):
-        self.authorized_post(url='conversion_parametrization/', json_data=None)
+        json_payload = dict(clipping_area=None, out_format=None, out_srs=None)
+        self.authorized_post(url='conversion_parametrization/', json_data=json_payload)
 
     @staticmethod
     def _extraction_processing_overdue(progress, extraction_order):

--- a/osmaxx/api_client/conversion_api_client.py
+++ b/osmaxx/api_client/conversion_api_client.py
@@ -38,7 +38,7 @@ class ConversionApiClient(JWTClient):
     def create_boundary(self, multipolygon, *, name):
         geo_json = json.loads(multipolygon.json)
         json_payload = dict(name=name, clipping_multi_polygon=geo_json)
-        self.authorized_post(url='clipping_area/', json_data=json_payload)
+        return self.authorized_post(url='clipping_area/', json_data=json_payload)
 
     @staticmethod
     def _extraction_processing_overdue(progress, extraction_order):

--- a/osmaxx/api_client/conversion_api_client.py
+++ b/osmaxx/api_client/conversion_api_client.py
@@ -41,7 +41,7 @@ class ConversionApiClient(JWTClient):
         return self.authorized_post(url='clipping_area/', json_data=json_payload)
 
     def create_parametrization(self, *, boundary, out_format, out_srs):
-        self.authorized_post(url=None, json_data=None)
+        self.authorized_post(url='conversion_parametrization/', json_data=None)
 
     @staticmethod
     def _extraction_processing_overdue(progress, extraction_order):

--- a/osmaxx/api_client/conversion_api_client.py
+++ b/osmaxx/api_client/conversion_api_client.py
@@ -45,13 +45,13 @@ class ConversionApiClient(JWTClient):
 
         Args:
             boundary: A dictionary as returned by create_boundary
-            out_format:
+            out_format: A string identifying the output format
             out_srs:
 
         Returns:
 
         """
-        json_payload = dict(clipping_area=boundary['id'], out_format=None, out_srs=None)
+        json_payload = dict(clipping_area=boundary['id'], out_format=out_format, out_srs=None)
         return self.authorized_post(url='conversion_parametrization/', json_data=json_payload)
 
     @staticmethod

--- a/tests/api_client/conversion_api_client_test.py
+++ b/tests/api_client/conversion_api_client_test.py
@@ -67,7 +67,7 @@ def test_create_parametrization_makes_authorized_post_with_json_payload(mocker):
 
 def test_create_parametrization_posts_to_conversion_parametrization_resource(mocker):
     c = ConversionApiClient()
-    mocker.patch.object(c, 'authorized_post', autospec=True)
+    mocker.patch.object(c, 'authorized_post', autospec=True, return_value=sentinel.POST_PARAMETRIZATION_REPLY)
     post_boundary_reply = dict(id=sentinel.CLIPPING_AREA_ID)
     c.create_parametrization(boundary=post_boundary_reply, out_format=sentinel.OUT_FORMAT, out_srs=sentinel.OUT_SRS)
     args, kwargs = c.authorized_post.call_args
@@ -76,11 +76,20 @@ def test_create_parametrization_posts_to_conversion_parametrization_resource(moc
 
 def test_create_parametrization_posts_payload_with_structure_expected_by_conversion_service_api(mocker):
     c = ConversionApiClient()
-    mocker.patch.object(c, 'authorized_post', autospec=True)
+    mocker.patch.object(c, 'authorized_post', autospec=True, return_value=sentinel.POST_PARAMETRIZATION_REPLY)
     post_boundary_reply = dict(id=sentinel.CLIPPING_AREA_ID)
     c.create_parametrization(boundary=post_boundary_reply, out_format=sentinel.OUT_FORMAT, out_srs=sentinel.OUT_SRS)
     args, kwargs = c.authorized_post.call_args
     assert_that(kwargs['json_data'].keys(), contains_inanyorder('out_format', 'out_srs', 'clipping_area'))
+
+
+def test_create_parametrization_returns_posts_request_reply(mocker):
+    c = ConversionApiClient()
+    mocker.patch.object(c, 'authorized_post', autospec=True, return_value=sentinel.POST_PARAMETRIZATION_REPLY)
+    post_boundary_reply = dict(id=sentinel.CLIPPING_AREA_ID)
+    result = \
+        c.create_parametrization(boundary=post_boundary_reply, out_format=sentinel.OUT_FORMAT, out_srs=sentinel.OUT_SRS)
+    assert result == sentinel.POST_PARAMETRIZATION_REPLY
 
 
 @pytest.fixture

--- a/tests/api_client/conversion_api_client_test.py
+++ b/tests/api_client/conversion_api_client_test.py
@@ -101,6 +101,15 @@ def test_create_parametrization_posts_out_format(mocker):
     assert kwargs['json_data']['out_format'] == sentinel.OUT_FORMAT
 
 
+def test_create_parametrization_posts_out_srs(mocker):
+    c = ConversionApiClient()
+    mocker.patch.object(c, 'authorized_post', autospec=True, return_value=sentinel.POST_PARAMETRIZATION_REPLY)
+    post_boundary_reply = dict(id=sentinel.CLIPPING_AREA_ID)
+    c.create_parametrization(boundary=post_boundary_reply, out_format=sentinel.OUT_FORMAT, out_srs=sentinel.OUT_SRS)
+    args, kwargs = c.authorized_post.call_args
+    assert kwargs['json_data']['out_srs'] == sentinel.OUT_SRS
+
+
 def test_create_parametrization_returns_posts_request_reply(mocker):
     c = ConversionApiClient()
     mocker.patch.object(c, 'authorized_post', autospec=True, return_value=sentinel.POST_PARAMETRIZATION_REPLY)

--- a/tests/api_client/conversion_api_client_test.py
+++ b/tests/api_client/conversion_api_client_test.py
@@ -74,6 +74,15 @@ def test_create_parametrization_posts_to_conversion_parametrization_resource(moc
     assert kwargs['url'] == 'conversion_parametrization/'
 
 
+def test_create_parametrization_posts_payload_with_structure_expected_by_conversion_service_api(mocker):
+    c = ConversionApiClient()
+    mocker.patch.object(c, 'authorized_post', autospec=True)
+    post_boundary_reply = dict(id=sentinel.CLIPPING_AREA_ID)
+    c.create_parametrization(boundary=post_boundary_reply, out_format=sentinel.OUT_FORMAT, out_srs=sentinel.OUT_SRS)
+    args, kwargs = c.authorized_post.call_args
+    assert_that(kwargs['json_data'].keys(), contains_inanyorder('out_format', 'out_srs', 'clipping_area'))
+
+
 @pytest.fixture
 def geos_multipolygon():
     return MultiPolygon(

--- a/tests/api_client/conversion_api_client_test.py
+++ b/tests/api_client/conversion_api_client_test.py
@@ -83,6 +83,15 @@ def test_create_parametrization_posts_payload_with_structure_expected_by_convers
     assert_that(kwargs['json_data'].keys(), contains_inanyorder('out_format', 'out_srs', 'clipping_area'))
 
 
+def test_create_parametrization_posts_clipping_area_id(mocker):
+    c = ConversionApiClient()
+    mocker.patch.object(c, 'authorized_post', autospec=True, return_value=sentinel.POST_PARAMETRIZATION_REPLY)
+    post_boundary_reply = dict(id=sentinel.CLIPPING_AREA_ID)
+    c.create_parametrization(boundary=post_boundary_reply, out_format=sentinel.OUT_FORMAT, out_srs=sentinel.OUT_SRS)
+    args, kwargs = c.authorized_post.call_args
+    assert kwargs['json_data']['clipping_area'] == sentinel.CLIPPING_AREA_ID
+
+
 def test_create_parametrization_returns_posts_request_reply(mocker):
     c = ConversionApiClient()
     mocker.patch.object(c, 'authorized_post', autospec=True, return_value=sentinel.POST_PARAMETRIZATION_REPLY)

--- a/tests/api_client/conversion_api_client_test.py
+++ b/tests/api_client/conversion_api_client_test.py
@@ -92,6 +92,15 @@ def test_create_parametrization_posts_clipping_area_id(mocker):
     assert kwargs['json_data']['clipping_area'] == sentinel.CLIPPING_AREA_ID
 
 
+def test_create_parametrization_posts_out_format(mocker):
+    c = ConversionApiClient()
+    mocker.patch.object(c, 'authorized_post', autospec=True, return_value=sentinel.POST_PARAMETRIZATION_REPLY)
+    post_boundary_reply = dict(id=sentinel.CLIPPING_AREA_ID)
+    c.create_parametrization(boundary=post_boundary_reply, out_format=sentinel.OUT_FORMAT, out_srs=sentinel.OUT_SRS)
+    args, kwargs = c.authorized_post.call_args
+    assert kwargs['json_data']['out_format'] == sentinel.OUT_FORMAT
+
+
 def test_create_parametrization_returns_posts_request_reply(mocker):
     c = ConversionApiClient()
     mocker.patch.object(c, 'authorized_post', autospec=True, return_value=sentinel.POST_PARAMETRIZATION_REPLY)

--- a/tests/api_client/conversion_api_client_test.py
+++ b/tests/api_client/conversion_api_client_test.py
@@ -57,6 +57,14 @@ def test_create_boundary_returns_posts_request_reply(mocker, geos_multipolygon):
     assert result == sentinel.POST_BOUNDARY_REPLY
 
 
+def test_create_parametrization_makes_authorized_post_with_json_payload(mocker):
+    c = ConversionApiClient()
+    mocker.patch.object(c, 'authorized_post', autospec=True)
+    post_boundary_reply = dict(id=sentinel.CLIPPING_AREA_ID)
+    c.create_parametrization(boundary=post_boundary_reply, out_format=sentinel.OUT_FORMAT, out_srs=sentinel.OUT_SRS)
+    c.authorized_post.assert_called_once_with(url=ANY, json_data=ANY)
+
+
 @pytest.fixture
 def geos_multipolygon():
     return MultiPolygon(

--- a/tests/api_client/conversion_api_client_test.py
+++ b/tests/api_client/conversion_api_client_test.py
@@ -10,14 +10,14 @@ from osmaxx.api_client.conversion_api_client import ConversionApiClient
 
 def test_create_boundary_makes_authorized_post_with_json_payload(mocker, geos_multipolygon):
     c = ConversionApiClient()
-    mocker.patch.object(c, 'authorized_post', autospec=True)
+    mocker.patch.object(c, 'authorized_post', autospec=True, return_value=sentinel.POST_BOUNDARY_REPLY)
     c.create_boundary(geos_multipolygon, name=sentinel.NAME)
     c.authorized_post.assert_called_once_with(url=ANY, json_data=ANY)
 
 
 def test_create_boundary_posts_to_clipping_area_resource(mocker, geos_multipolygon):
     c = ConversionApiClient()
-    mocker.patch.object(c, 'authorized_post', autospec=True)
+    mocker.patch.object(c, 'authorized_post', autospec=True, return_value=sentinel.POST_BOUNDARY_REPLY)
     c.create_boundary(geos_multipolygon, name=sentinel.NAME)
     args, kwargs = c.authorized_post.call_args
     assert kwargs['url'] == 'clipping_area/'
@@ -25,7 +25,7 @@ def test_create_boundary_posts_to_clipping_area_resource(mocker, geos_multipolyg
 
 def test_create_boundary_posts_payload_with_structure_expected_by_conversion_service_api(mocker, geos_multipolygon):
     c = ConversionApiClient()
-    mocker.patch.object(c, 'authorized_post', autospec=True)
+    mocker.patch.object(c, 'authorized_post', autospec=True, return_value=sentinel.POST_BOUNDARY_REPLY)
     c.create_boundary(geos_multipolygon, name=sentinel.NAME)
     args, kwargs = c.authorized_post.call_args
     assert_that(kwargs['json_data'].keys(), contains_inanyorder('name', 'clipping_multi_polygon'))
@@ -33,7 +33,7 @@ def test_create_boundary_posts_payload_with_structure_expected_by_conversion_ser
 
 def test_create_boundary_posts_name(mocker, geos_multipolygon):
     c = ConversionApiClient()
-    mocker.patch.object(c, 'authorized_post', autospec=True)
+    mocker.patch.object(c, 'authorized_post', autospec=True, return_value=sentinel.POST_BOUNDARY_REPLY)
     c.create_boundary(geos_multipolygon, name=sentinel.NAME)
     args, kwargs = c.authorized_post.call_args
     assert kwargs['json_data']['name'] == sentinel.NAME
@@ -41,13 +41,20 @@ def test_create_boundary_posts_name(mocker, geos_multipolygon):
 
 def test_create_boundary_posts_geojson(mocker, geos_multipolygon):
     c = ConversionApiClient()
-    mocker.patch.object(c, 'authorized_post', autospec=True)
+    mocker.patch.object(c, 'authorized_post', autospec=True, return_value=sentinel.POST_BOUNDARY_REPLY)
     c.create_boundary(geos_multipolygon, name=sentinel.NAME)
     args, kwargs = c.authorized_post.call_args
     assert kwargs['json_data']['clipping_multi_polygon'] == {
         "type": "MultiPolygon",
         "coordinates": nested_list(geos_multipolygon.coords)
     }
+
+
+def test_create_boundary_returns_posts_request_reply(mocker, geos_multipolygon):
+    c = ConversionApiClient()
+    mocker.patch.object(c, 'authorized_post', autospec=True, return_value=sentinel.POST_BOUNDARY_REPLY)
+    result = c.create_boundary(geos_multipolygon, name=sentinel.NAME)
+    assert result == sentinel.POST_BOUNDARY_REPLY
 
 
 @pytest.fixture

--- a/tests/api_client/conversion_api_client_test.py
+++ b/tests/api_client/conversion_api_client_test.py
@@ -65,6 +65,15 @@ def test_create_parametrization_makes_authorized_post_with_json_payload(mocker):
     c.authorized_post.assert_called_once_with(url=ANY, json_data=ANY)
 
 
+def test_create_parametrization_posts_to_conversion_parametrization_resource(mocker):
+    c = ConversionApiClient()
+    mocker.patch.object(c, 'authorized_post', autospec=True)
+    post_boundary_reply = dict(id=sentinel.CLIPPING_AREA_ID)
+    c.create_parametrization(boundary=post_boundary_reply, out_format=sentinel.OUT_FORMAT, out_srs=sentinel.OUT_SRS)
+    args, kwargs = c.authorized_post.call_args
+    assert kwargs['url'] == 'conversion_parametrization/'
+
+
 @pytest.fixture
 def geos_multipolygon():
     return MultiPolygon(

--- a/tests/excerptexport/test_conversion_api_client.py
+++ b/tests/excerptexport/test_conversion_api_client.py
@@ -75,7 +75,6 @@ class ConversionApiClientTestCase(TestCase):
     @mock.patch.object(ConversionApiClient, 'create_job', side_effect=[sentinel.job_1, sentinel.job_2])
     @mock.patch.object(
         ConversionApiClient, 'create_parametrization',
-        create=True,  # TODO: remove 'create' once implemented
         side_effect=[sentinel.parametrization_1, sentinel.parametrization_2],
     )
     @mock.patch.object(ConversionApiClient, 'create_boundary')


### PR DESCRIPTION
connected to #406 (implements part of it)

#### Implements
* `ConversionApiClient.create_parametrization(...)`

#### Already implemented in #416
* `ExtractionOrder.forward_to_conversion_service(...)`
* `ConversionApiClient.create_boundary(...)`

#### Still to be implemented
(already being used by implementation of `ExtractionOrder.forward_to_conversion_service(...)`):
* `ConversionApiClient.api_client.create_job(...)`

### Reviewed by
- [x] @hixi
- [ ] @beneditatan