### PR TITLE
fix: use extraction_order ID consistently in mocks

### DIFF
--- a/tests/excerptexport/test_conversion_api_client.py
+++ b/tests/excerptexport/test_conversion_api_client.py
@@ -7,7 +7,7 @@ import os
 
 import pytest
 from django.core.urlresolvers import resolve
-from hamcrest import assert_that, contains_inanyorder, matches_regexp, match_equality, close_to as is_close_to
+from hamcrest import assert_that, contains_inanyorder, close_to as is_close_to
 from requests import HTTPError
 
 from osmaxx.api_client import ConversionApiClient, API_client
@@ -50,7 +50,7 @@ def test_failed_login():
 @pytest.fixture
 def job_progress_request():
     request = Mock()
-    request.build_absolute_uri.return_value = 'http://the-host.example.com/job_progress/tracker/1/'
+    request.build_absolute_uri.return_value = 'http://the-host.example.com/job_progress/tracker/23/'
     return request
 
 
@@ -139,7 +139,7 @@ def test_create_job(api_client, extraction_order, job_progress_request):
     assert extraction_order.state == ExtractionOrderState.QUEUED
     assert extraction_order.process_id == response.json().get('rq_job_id')
     assert extraction_order.process_id is not None
-    job_progress_request.build_absolute_uri.assert_called_with(a_string_matching_regexp('/job_progress/tracker/\d+/'))
+    job_progress_request.build_absolute_uri.assert_called_with('/job_progress/tracker/23/')
 
 
 @vcr.use_cassette('fixtures/vcr/conversion_api-test_create_job.yml')  # Intentionally same as for test_create_job()
@@ -153,7 +153,7 @@ def test_callback_url_of_created_job_resolves_to_job_updater(api_client, extract
 
     match = resolve(callback_path)
     assert match.func == tracker
-    job_progress_request.build_absolute_uri.assert_called_with(a_string_matching_regexp('/job_progress/tracker/\d+/'))
+    job_progress_request.build_absolute_uri.assert_called_with('/job_progress/tracker/23/')
 
 
 @vcr.use_cassette('fixtures/vcr/conversion_api-test_create_job.yml')  # Intentionally same as for test_create_job()
@@ -167,7 +167,7 @@ def test_callback_url_of_created_job_refers_to_correct_extraction_order(api_clie
 
     match = resolve(callback_path)
     assert match.kwargs == {'order_id': str(extraction_order.id)}
-    job_progress_request.build_absolute_uri.assert_called_with(a_string_matching_regexp('/job_progress/tracker/\d+/'))
+    job_progress_request.build_absolute_uri.assert_called_with('/job_progress/tracker/23/')
 
 
 @vcr.use_cassette('fixtures/vcr/conversion_api-test_create_job.yml')  # Intentionally same as for test_create_job()
@@ -180,7 +180,7 @@ def test_callback_url_would_reach_this_django_instance(api_client, extraction_or
     scheme, host, callback_path, params, *_ = urlparse(callback_url)
     assert scheme.startswith('http')  # also matches https
     assert host == 'the-host.example.com'
-    job_progress_request.build_absolute_uri.assert_called_with(a_string_matching_regexp('/job_progress/tracker/\d+/'))
+    job_progress_request.build_absolute_uri.assert_called_with('/job_progress/tracker/23/')
 
 
 def test_download_files(api_client, extraction_order, job_progress_request):
@@ -212,7 +212,7 @@ def test_download_files(api_client, extraction_order, job_progress_request):
             len(extraction_order.output_files.order_by('id')[1].file.read()),
             is_close_to(368378, delta=10000)
         )
-    job_progress_request.build_absolute_uri.assert_called_with(a_string_matching_regexp('/job_progress/tracker/\d+/'))
+    job_progress_request.build_absolute_uri.assert_called_with('/job_progress/tracker/23/')
 
 
 def test_order_status_processing(api_client, extraction_order, job_progress_request):
@@ -235,7 +235,7 @@ def test_order_status_processing(api_client, extraction_order, job_progress_requ
         assert extraction_order.state == ExtractionOrderState.PROCESSING
         assert extraction_order.state != ExtractionOrderState.INITIALIZED
         assert extraction_order.output_files.count() == 0
-    job_progress_request.build_absolute_uri.assert_called_with(a_string_matching_regexp('/job_progress/tracker/\d+/'))
+    job_progress_request.build_absolute_uri.assert_called_with('/job_progress/tracker/23/')
 
 
 def test_order_status_done(api_client, extraction_order, job_progress_request):
@@ -257,8 +257,4 @@ def test_order_status_done(api_client, extraction_order, job_progress_request):
 
         api_client.update_order_status(extraction_order)
         assert extraction_order.state == ExtractionOrderState.FINISHED
-    job_progress_request.build_absolute_uri.assert_called_with(a_string_matching_regexp('/job_progress/tracker/\d+/'))
-
-
-def a_string_matching_regexp(pattern):
-    return match_equality(matches_regexp(pattern))
+    job_progress_request.build_absolute_uri.assert_called_with('/job_progress/tracker/23/')


### PR DESCRIPTION
This inconsistency introduced in #426 with d61c77d broke re-recordability of the VCR casettes.

### Reviewed by
- [x] @hixi

connected to #406 because #426 was, too