### PR TITLE
Eliminate unused CANCELED order state

### DIFF
--- a/osmaxx/excerptexport/models/extraction_order.py
+++ b/osmaxx/excerptexport/models/extraction_order.py
@@ -16,10 +16,9 @@ class ExtractionOrderState(enum.Enum):
     QUEUED = 2
     PROCESSING = 3
     FINISHED = 4
-    CANCELED = 5
     FAILED = 6
 
-FINAL_STATES = {ExtractionOrderState.FINISHED, ExtractionOrderState.CANCELED, ExtractionOrderState.FAILED}
+FINAL_STATES = {ExtractionOrderState.FINISHED, ExtractionOrderState.FAILED}
 
 
 CONVERSION_PROGRESS_TO_EXTRACTION_ORDER_STATE_MAPPING = {

--- a/osmaxx/excerptexport/static/excerptexport/stylesheets/main.css
+++ b/osmaxx/excerptexport/static/excerptexport/stylesheets/main.css
@@ -255,7 +255,6 @@ table th                    { padding-right: 2rem; }
 [data-order-status="QUEUED"] { background: lightyellow; border: 0.1rem solid yellow; }
 [data-order-status="PROCESSING"] { background: aliceblue; border: 0.1rem solid steelblue; }
 [data-order-status="FINISHED"] { background: honeydew; border: 0.1rem solid seagreen; }
-[data-order-status="CANCELED"] { background: peachpuff; border: 0.1rem solid maroon; }
 [data-order-status="FAILED"] { background: mistyrose; border: 0.1rem solid maroon; }
 
 .symbol.undefined { color: maroon; }
@@ -264,7 +263,6 @@ table th                    { padding-right: 2rem; }
 .symbol.rotated90deg { display: inline-block; -ms-transform: rotate(90deg); -webkit-transform: rotate(90deg); transform: rotate(90deg); }
 .symbol.processing { color: dodgerblue; }
 .symbol.finished { color: seagreen; }
-.symbol.canceled { color: maroon; }
 .symbol.failed { color: darkred; }
 
 .download_files li[data-file-deleted] { opacity: 0.5; }

--- a/osmaxx/excerptexport/templates/excerptexport/partials/status.html
+++ b/osmaxx/excerptexport/templates/excerptexport/partials/status.html
@@ -10,8 +10,6 @@
             <span class="symbol processing" title="{{ state }}">&#8635;</span>
         {% elif state == 'finished' %}
             <span class="symbol finished" title="{{ state }}">&check;</span>
-        {% elif state == 'canceled' %}
-            <span class="symbol canceled" title="{{ state }}">&Chi;</span>
         {% elif state == 'failed' %}
             <span class="symbol failed" title="{{ state }}">&#x2716;</span>
         {% endif %}

--- a/tests/job_progress/test_job_progress.py
+++ b/tests/job_progress/test_job_progress.py
@@ -341,8 +341,6 @@ class OrderUpdateTest(TestCase):
             ExtractionOrder.objects.create(orderer=test_user, state=ExtractionOrderState.FINISHED)
         for i in range(8):
             ExtractionOrder.objects.create(orderer=test_user, state=ExtractionOrderState.FAILED)
-        for i in range(16):
-            ExtractionOrder.objects.create(orderer=test_user, state=ExtractionOrderState.CANCELED)
         for i in range(32):
             ExtractionOrder.objects.create(orderer=other_user)
         self.client.login(username='user', password='pw')


### PR DESCRIPTION
There are currently no plans to allow cancellation of jobs. If we ever implement that, this code would quickly be resurrected or re-implemented. Until then, YAGNI.

### Reviewed by
- [x] @hixi