### PR TITLE
don't crash in frontend if a finished conversion job has not result file

### DIFF
--- a/osmaxx/api_client/conversion_api_client.py
+++ b/osmaxx/api_client/conversion_api_client.py
@@ -71,7 +71,10 @@ class ConversionApiClient(JWTClient):
 
     def get_result_file(self, job_id):
         download_url = self._get_result_file_url(job_id)
-        return LazyChunkedRemoteFile(download_url, download_function=self.authorized_get)
+        if download_url:
+            return LazyChunkedRemoteFile(download_url, download_function=self.authorized_get)
+        else:
+            raise ResultFileNotAvailableError
 
     def _get_result_file_url(self, job_id):
         job_detail_url = CONVERSION_JOB_URL + '{}/'.format(job_id)
@@ -146,3 +149,7 @@ class ConversionApiClient(JWTClient):
         except HTTPError as e:
             return reasons_for(e)
         return response.json()
+
+
+class ResultFileNotAvailableError(RuntimeError):
+    pass

--- a/osmaxx/excerptexport/models/export.py
+++ b/osmaxx/excerptexport/models/export.py
@@ -75,10 +75,7 @@ class Export(models.Model):
                 emissary.success(status_changed_message)
             except ResultFileNotAvailableError:
                 logger.error(
-                    'Export {export_id}: Job {job_id} finished, but file not available.'.format(
-                        export_id=self.id,
-                        job_id=self.conversion_service_job_id,
-                    )
+                    self._get_job_finished_but_result_file_missing_log_message()
                 )
                 emissary.warn(
                     _("{} But the result file is not available.").format(status_changed_message)
@@ -94,6 +91,12 @@ class Export(models.Model):
             'job_progress/messages/export_status_changed.unsave_text',
             context=view_context,
         ).strip()
+
+    def _get_job_finished_but_result_file_missing_log_message(self):
+        return 'Export {export_id}: Job {job_id} finished, but file not available.'.format(
+            export_id=self.id,
+            job_id=self.conversion_service_job_id,
+        )
 
     def _fetch_result_file(self):
         from osmaxx.api_client import ConversionApiClient

--- a/osmaxx/excerptexport/models/export.py
+++ b/osmaxx/excerptexport/models/export.py
@@ -74,12 +74,8 @@ class Export(models.Model):
                 self._fetch_result_file()
                 emissary.success(status_changed_message)
             except ResultFileNotAvailableError:
-                logger.error(
-                    self._get_job_finished_but_result_file_missing_log_message()
-                )
-                emissary.warn(
-                    _("{} But the result file is not available.").format(status_changed_message)
-                )
+                logger.error(self._get_job_finished_but_result_file_missing_log_message())
+                emissary.warn(_("{} But the result file is not available.").format(status_changed_message))
         else:
             emissary.info(status_changed_message)
         self.extraction_order.send_email_if_all_exports_done(incoming_request)

--- a/osmaxx/excerptexport/models/export.py
+++ b/osmaxx/excerptexport/models/export.py
@@ -65,13 +65,14 @@ class Export(models.Model):
     def _handle_changed_status(self, *, incoming_request):
         from osmaxx.utilities.shortcuts import Emissary
         emissary = Emissary(recipient=self.extraction_order.orderer)
+        status_changed_message = self._get_export_status_changed_message()
         if self.status == FAILED:
-            emissary.error(self._get_export_status_changed_message())
+            emissary.error(status_changed_message)
         elif self.status == FINISHED:
             from osmaxx.api_client.conversion_api_client import ResultFileNotAvailableError
             try:
                 self._fetch_result_file()
-                emissary.success(self._get_export_status_changed_message())
+                emissary.success(status_changed_message)
             except ResultFileNotAvailableError:
                 logger.error(
                     'Export {export_id}: Job {job_id} finished, but file not available.'.format(
@@ -80,10 +81,10 @@ class Export(models.Model):
                     )
                 )
                 emissary.warn(
-                    _("{} But the result file is not available.").format(self._get_export_status_changed_message())
+                    _("{} But the result file is not available.").format(status_changed_message)
                 )
         else:
-            emissary.info(self._get_export_status_changed_message())
+            emissary.info(status_changed_message)
         self.extraction_order.send_email_if_all_exports_done(incoming_request)
 
     def _get_export_status_changed_message(self):

--- a/osmaxx/excerptexport/models/export.py
+++ b/osmaxx/excerptexport/models/export.py
@@ -1,3 +1,4 @@
+import logging
 import uuid
 
 from django.db import models
@@ -12,6 +13,8 @@ from osmaxx.utils.private_system_storage import get_default_private_storage
 INITIAL = 'initial'
 INITIAL_CHOICE = (INITIAL, _('initial'))
 STATUS_CHOICES = (INITIAL_CHOICE,) + statuses.STATUS_CHOICES
+
+logger = logging.getLogger(__name__)
 
 
 class Export(models.Model):
@@ -65,8 +68,20 @@ class Export(models.Model):
         if self.status == FAILED:
             emissary.error(self._get_export_status_changed_message())
         elif self.status == FINISHED:
-            self._fetch_result_file()
-            emissary.success(self._get_export_status_changed_message())
+            from osmaxx.api_client.conversion_api_client import ResultFileNotAvailableError
+            try:
+                self._fetch_result_file()
+                emissary.success(self._get_export_status_changed_message())
+            except ResultFileNotAvailableError:
+                logger.error(
+                    'Export {export_id}: Job {job_id} finished, but file not available.'.format(
+                        export_id=self.id,
+                        job_id=self.conversion_service_job_id,
+                    )
+                )
+                emissary.warn(
+                    _("{} But the result file is not available.").format(self._get_export_status_changed_message())
+                )
         else:
             emissary.info(self._get_export_status_changed_message())
         self.extraction_order.send_email_if_all_exports_done(incoming_request)


### PR DESCRIPTION
Don't crash in front-end if a finished conversion job has not result file.

Instead, display an on-screen warning to the user and log an error.

### Reviewed by
- [x] @hixi