### PR TITLE
update coverage configuration exclusions

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,5 @@
 [run]
-omit = tests/*,osmaxx/converters/converter_settings.py,osmaxx/rest_api/urls.py
+omit = tests/*
 
 [report]
 show_missing = True


### PR DESCRIPTION
Reviewed by:
- [x] @das-g 

We shouldn't exclude anything, besides the tests themselves.