### PR TITLE
Feature/#423 nonop way classification

### DIFF
--- a/osmaxx/conversion/converters/converter_gis/bootstrap/sql/filter/create_view/view_nonop_l.sql
+++ b/osmaxx/conversion/converters/converter_gis/bootstrap/sql/filter/create_view/view_nonop_l.sql
@@ -4,6 +4,7 @@ CREATE OR REPLACE VIEW view_osmaxx.nonop_l AS SELECT
     geomtype,
     geom,
     type,
+    sub_type,
     name,
     label,
     tags,

--- a/osmaxx/conversion/converters/converter_gis/bootstrap/sql/filter/nonop/000_setup-drop_and_recreate_table_nonop.sql
+++ b/osmaxx/conversion/converters/converter_gis/bootstrap/sql/filter/nonop/000_setup-drop_and_recreate_table_nonop.sql
@@ -9,6 +9,7 @@ CREATE TABLE osmaxx.nonop_l (
     geomtype char(1),
     geom geometry(MULTILINESTRING, 4326),
     type text,
+    sub_type text,
     name text,
     name_en text,
     name_fr text,

--- a/osmaxx/conversion/converters/converter_gis/bootstrap/sql/filter/nonop/005_lifecycle_view.sql
+++ b/osmaxx/conversion/converters/converter_gis/bootstrap/sql/filter/nonop/005_lifecycle_view.sql
@@ -3,16 +3,16 @@ CREATE OR REPLACE VIEW osmaxx.lifecycle_l AS
     osm_id,
     CASE
       WHEN highway = 'planned' THEN tags -> 'planned'
-      WHEN highway = 'disused' THEN tags -> 'disused'
       WHEN highway = 'construction' THEN tags -> 'construction'
+      WHEN highway = 'disused' THEN tags -> 'disused'
       WHEN highway = 'abandoned' THEN tags -> 'abandoned'
     END AS highway,
     CASE
       WHEN highway = 'planned' OR railway = 'planned' THEN 'P'
-      WHEN highway = 'disused' OR railway = 'disused' THEN 'D'
       WHEN highway = 'construction' OR railway = 'construction' THEN 'C'
+      WHEN highway = 'disused' OR railway = 'disused' THEN 'D'
       WHEN highway = 'abandoned' OR railway = 'abandoned' THEN 'A'
     END AS status
   FROM osm_line
-  WHERE highway = 'planned' OR highway = 'disused' OR highway = 'construction' OR highway = 'abandoned'
-        OR railway = 'planned' OR railway = 'disused' OR railway = 'construction' OR railway = 'abandoned';
+  WHERE highway = 'planned' OR highway = 'construction' OR highway = 'disused' OR highway = 'abandoned'
+        OR railway = 'planned' OR railway = 'construction' OR railway = 'disused' OR railway = 'abandoned';

--- a/osmaxx/conversion/converters/converter_gis/bootstrap/sql/filter/nonop/005_lifecycle_view.sql
+++ b/osmaxx/conversion/converters/converter_gis/bootstrap/sql/filter/nonop/005_lifecycle_view.sql
@@ -6,7 +6,13 @@ CREATE OR REPLACE VIEW osmaxx.lifecycle_l AS
       WHEN highway = 'disused' THEN tags -> 'disused'
       WHEN highway = 'construction' THEN tags -> 'construction'
       WHEN highway = 'abandoned' THEN tags -> 'abandoned'
-    END AS highway
+    END AS highway,
+    CASE
+      WHEN highway = 'planned' OR railway = 'planned' THEN 'P'
+      WHEN highway = 'disused' OR railway = 'disused' THEN 'D'
+      WHEN highway = 'construction' OR railway = 'construction' THEN 'C'
+      WHEN highway = 'abandoned' OR railway = 'abandoned' THEN 'A'
+    END AS status
   FROM osm_line
   WHERE highway = 'planned' OR highway = 'disused' OR highway = 'construction' OR highway = 'abandoned'
         OR railway = 'planned' OR railway = 'disused' OR railway = 'construction' OR railway = 'abandoned';

--- a/osmaxx/conversion/converters/converter_gis/bootstrap/sql/filter/nonop/005_lifecycle_view.sql
+++ b/osmaxx/conversion/converters/converter_gis/bootstrap/sql/filter/nonop/005_lifecycle_view.sql
@@ -2,24 +2,26 @@ CREATE OR REPLACE VIEW osmaxx.lifecycle_l AS
   SELECT
     osm_id,
     CASE
-      WHEN highway IS NOT NULL THEN
+      WHEN highway IS NOT NULL THEN coalesce(
         CASE
           WHEN highway = 'planned' THEN tags -> 'planned'
           WHEN highway = 'construction' THEN tags -> 'construction'
           WHEN highway = 'disused' THEN tags -> 'disused'
           WHEN highway = 'abandoned' THEN tags -> 'abandoned'
-          ELSE 'yes'
-        END
+        END,
+        'yes'
+      )
     END AS highway,
     CASE
-      WHEN railway IS NOT NULL THEN
+      WHEN railway IS NOT NULL THEN coalesce(
         CASE
           WHEN railway = 'planned' THEN tags -> 'planned'
           WHEN railway = 'construction' THEN tags -> 'construction'
           WHEN railway = 'disused' THEN tags -> 'disused'
           WHEN railway = 'abandoned' THEN tags -> 'abandoned'
-          ELSE 'yes'
-        END
+        END,
+        'yes'
+      )
     END AS railway,
     CASE
       WHEN highway = 'planned' OR railway = 'planned' THEN 'P'

--- a/osmaxx/conversion/converters/converter_gis/bootstrap/sql/filter/nonop/005_lifecycle_view.sql
+++ b/osmaxx/conversion/converters/converter_gis/bootstrap/sql/filter/nonop/005_lifecycle_view.sql
@@ -2,11 +2,25 @@ CREATE OR REPLACE VIEW osmaxx.lifecycle_l AS
   SELECT
     osm_id,
     CASE
-      WHEN highway = 'planned' THEN tags -> 'planned'
-      WHEN highway = 'construction' THEN tags -> 'construction'
-      WHEN highway = 'disused' THEN tags -> 'disused'
-      WHEN highway = 'abandoned' THEN tags -> 'abandoned'
+      WHEN highway IS NOT NULL THEN
+        CASE
+          WHEN highway = 'planned' THEN tags -> 'planned'
+          WHEN highway = 'construction' THEN tags -> 'construction'
+          WHEN highway = 'disused' THEN tags -> 'disused'
+          WHEN highway = 'abandoned' THEN tags -> 'abandoned'
+          ELSE 'yes'
+        END
     END AS highway,
+    CASE
+      WHEN railway IS NOT NULL THEN
+        CASE
+          WHEN railway = 'planned' THEN tags -> 'planned'
+          WHEN railway = 'construction' THEN tags -> 'construction'
+          WHEN railway = 'disused' THEN tags -> 'disused'
+          WHEN railway = 'abandoned' THEN tags -> 'abandoned'
+          ELSE 'yes'
+        END
+    END AS railway,
     CASE
       WHEN highway = 'planned' OR railway = 'planned' THEN 'P'
       WHEN highway = 'construction' OR railway = 'construction' THEN 'C'

--- a/osmaxx/conversion/converters/converter_gis/bootstrap/sql/filter/nonop/005_lifecycle_view.sql
+++ b/osmaxx/conversion/converters/converter_gis/bootstrap/sql/filter/nonop/005_lifecycle_view.sql
@@ -1,0 +1,12 @@
+CREATE OR REPLACE VIEW osmaxx.lifecycle_l AS
+  SELECT
+    osm_id,
+    CASE
+      WHEN highway = 'planned' THEN tags -> 'planned'
+      WHEN highway = 'disused' THEN tags -> 'disused'
+      WHEN highway = 'construction' THEN tags -> 'construction'
+      WHEN highway = 'abandoned' THEN tags -> 'abandoned'
+    END AS highway
+  FROM osm_line
+  WHERE highway = 'planned' OR highway = 'disused' OR highway = 'construction' OR highway = 'abandoned'
+        OR railway = 'planned' OR railway = 'disused' OR railway = 'construction' OR railway = 'abandoned';

--- a/osmaxx/conversion/converters/converter_gis/bootstrap/sql/filter/nonop/010_nonop.sql
+++ b/osmaxx/conversion/converters/converter_gis/bootstrap/sql/filter/nonop/010_nonop.sql
@@ -11,20 +11,28 @@ INSERT INTO osmaxx.nonop_l
 -- Differentiating between Highway and Railway --
     case
     when osm_line.highway is not null then 'highway'
-    when railway is not null then 'railway'
+    when osm_line.railway is not null then 'railway'
     end as type,
     case
-      when osmaxx.lifecycle_l.highway='track' then
+      when osm_line.highway is not null then
         case
-          when tracktype in ('grade1','grade2','grade3','grade4','grade5') then tracktype
-          else 'track'
+          when osmaxx.lifecycle_l.highway='track' then
+            case
+              when tracktype in ('grade1','grade2','grade3','grade4','grade5') then tracktype
+              else 'track'
+            end
+          when osmaxx.lifecycle_l.highway in ('motorway','trunk','primary','secondary','tertiary',
+                'unclassified','residential','living_street','pedestrian',
+                'motorway_link','trunk_link','primary_link','secondary_link',
+                'service','track','bridleway','cycleway','footway',
+                'path','steps') then osmaxx.lifecycle_l.highway
+          else 'road'
         end
-      when osmaxx.lifecycle_l.highway in ('motorway','trunk','primary','secondary','tertiary',
-            'unclassified','residential','living_street','pedestrian',
-            'motorway_link','trunk_link','primary_link','secondary_link',
-            'service','track','bridleway','cycleway','footway',
-            'path','steps') then osmaxx.lifecycle_l.highway
-      else 'road'
+      when osm_line.railway is not null then
+        case
+          when osmaxx.lifecycle_l.railway in ('rail','light_rail','subway','tram','monorail','narrow_gauge','miniature','funicular','rack') then osmaxx.lifecycle_l.railway
+          else 'railway'
+        end
     end as sub_type,
     name as name,
     "name:en" as name_en,

--- a/osmaxx/conversion/converters/converter_gis/bootstrap/sql/filter/nonop/010_nonop.sql
+++ b/osmaxx/conversion/converters/converter_gis/bootstrap/sql/filter/nonop/010_nonop.sql
@@ -10,11 +10,11 @@ INSERT INTO osmaxx.nonop_l
     ST_Multi(way) AS geom,
 -- Differentiating between Highway and Railway --
     case
-    when osm_line.highway is not null then 'highway'
-    when osm_line.railway is not null then 'railway'
+    when osmaxx.lifecycle_l.highway is not null then 'highway'
+    when osmaxx.lifecycle_l.railway is not null then 'railway'
     end as type,
     case
-      when osm_line.highway is not null then
+      when osmaxx.lifecycle_l.highway is not null then
         case
           when osmaxx.lifecycle_l.highway='track' then
             case
@@ -28,7 +28,7 @@ INSERT INTO osmaxx.nonop_l
                 'path','steps') then osmaxx.lifecycle_l.highway
           else 'road'
         end
-      when osm_line.railway is not null then
+      when osmaxx.lifecycle_l.railway is not null then
         case
           when osmaxx.lifecycle_l.railway in ('rail','light_rail','subway','tram','monorail','narrow_gauge','miniature','funicular','rack') then osmaxx.lifecycle_l.railway
           else 'railway'

--- a/osmaxx/conversion/converters/converter_gis/bootstrap/sql/filter/nonop/010_nonop.sql
+++ b/osmaxx/conversion/converters/converter_gis/bootstrap/sql/filter/nonop/010_nonop.sql
@@ -55,12 +55,6 @@ INSERT INTO osmaxx.nonop_l
     end as tunnel,
 
     z_order as z_order,
--- Differentiating the different types of transport --
-    case
-     when osm_line.highway='planned' or railway='planned' then 'P'
-     when osm_line.highway='disused'  or railway='disused' then 'D'
-     when osm_line.highway='construction'  or railway='construction' then 'C'
-     when osm_line.highway='abandoned'  or railway='abandoned' then 'A'
-     end as status
+    status AS status
  FROM osm_line
    JOIN osmaxx.lifecycle_l ON osm_line.osm_id = osmaxx.lifecycle_l.osm_id;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -301,6 +301,7 @@ END
 class TagCombination(Mapping):
     def __init__(self, *args, **kwargs):
         self.__tags = frozendict(*args, **kwargs)
+        self.__hash = hash(frozenset(self.items()))
 
     def __getitem__(self, item):
         return self.__tags[item]
@@ -313,3 +314,6 @@ class TagCombination(Mapping):
 
     def __str__(self):
         return ' '.join("{key}={value}".format(key=key, value=value) for key, value in self.items())
+
+    def __hash__(self):
+        return self.__hash

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -300,7 +300,9 @@ END
 
 class TagCombination(Mapping):
     def __init__(self, *args, **kwargs):
-        self.__tags = frozendict(*args, **kwargs)
+        tags = dict(osm_id=id(self))
+        tags.update(*args, **kwargs)
+        self.__tags = frozendict(tags)
         self.__hash = hash(frozenset(self.items()))
 
     def __getitem__(self, item):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,12 @@
 # pylint: disable=C0111
 import os
 import tempfile
+from collections import Mapping
 from datetime import timedelta
 
 import pytest
+
+from osmaxx.utils.frozendict import frozendict
 
 test_data_dir = os.path.join(os.path.dirname(__file__), 'test_data')
 
@@ -293,3 +296,20 @@ polygon-1
 END
 END
 '''
+
+
+class TagCombination(Mapping):
+    def __init__(self, *args, **kwargs):
+        self.__tags = frozendict(*args, **kwargs)
+
+    def __getitem__(self, item):
+        return self.__tags[item]
+
+    def __iter__(self):
+        return iter(self.__tags)
+
+    def __len__(self):
+        return len(self.__tags)
+
+    def __str__(self):
+        return ' '.join("{key}={value}".format(key=key, value=value) for key, value in self.items())

--- a/tests/conversion/converters/bootstrap_test.py
+++ b/tests/conversion/converters/bootstrap_test.py
@@ -35,6 +35,7 @@ class BootStrapperTest(TestCase):
                 'sql/filter/natural/020_setup-drop_and_recreate_table_natural_p.sql',
                 'sql/filter/natural/030_natural_p.sql',
                 'sql/filter/nonop/000_setup-drop_and_recreate_table_nonop.sql',
+                'sql/filter/nonop/005_lifecycle_view.sql',
                 'sql/filter/nonop/010_nonop.sql',
                 'sql/filter/geoname/000_setup-geoname_table.sql',
                 'sql/filter/geoname/010_geoname_l.sql',

--- a/tests/inside_worker_test/label_sql_test.py
+++ b/tests/inside_worker_test/label_sql_test.py
@@ -1,6 +1,7 @@
 import pytest
 import sqlalchemy
 
+from tests.conftest import TagCombination
 from tests.inside_worker_test.conftest import sql_from_bootstrap_relative_location, slow
 from tests.inside_worker_test.declarative_schema import osm_models
 
@@ -8,27 +9,33 @@ xeno = "大洲南部広域農道"
 xeno_transliterated = 'dà zhōu nán bù guǎng yù nóng dào'
 latin = 'Turicum'
 
+NAME_TAG_COMBINATIONS = tuple(
+    TagCombination(name_tags) for name_tags in
+    [
+        {'name': latin, 'name:en': 'latin-en', 'name:fr': 'latin-fr', 'name:es': 'latin-es', 'name:de': 'latin-de', 'expected_label': latin},
+        {'name': xeno, 'name:en': 'latin-en', 'name:fr': 'latin-fr', 'name:es': 'latin-es', 'name:de': 'latin-de', 'expected_label': 'latin-en'},
+        {'name': latin, 'name:en': None, 'name:fr': None, 'name:es': None, 'name:de': None, 'expected_label': latin},
 
-@pytest.fixture(params=[
-    {'name': latin, 'name:en': 'latin-en', 'name:fr': 'latin-fr', 'name:es': 'latin-es', 'name:de': 'latin-de', 'expected_label': latin},
-    {'name': xeno, 'name:en': 'latin-en', 'name:fr': 'latin-fr', 'name:es': 'latin-es', 'name:de': 'latin-de', 'expected_label': 'latin-en'},
-    {'name': latin, 'name:en': None, 'name:fr': None, 'name:es': None, 'name:de': None, 'expected_label': latin},
-    # correct order of fallbacks
-    {'name': None, 'name:en': 'latin-en', 'name:fr': 'latin-fr', 'name:es': 'latin-es', 'name:de': 'latin-de', 'expected_label': 'latin-en'},
-    {'name': None, 'name:en': None, 'name:fr': 'latin-fr', 'name:es': 'latin-es', 'name:de': 'latin-de', 'expected_label': 'latin-fr'},
-    {'name': None, 'name:en': None, 'name:fr': None, 'name:es': 'latin-es', 'name:de': 'latin-de', 'expected_label': 'latin-es'},
-    {'name': None, 'name:en': None, 'name:fr': None, 'name:es': None, 'name:de': 'latin-de', 'expected_label': 'latin-de'},
-    {'name': None, 'name:en': None, 'name:fr': None, 'name:es': None, 'name:de': None, 'expected_label': None},
+        # correct order of fallbacks
+        {'name': None, 'name:en': 'latin-en', 'name:fr': 'latin-fr', 'name:es': 'latin-es', 'name:de': 'latin-de', 'expected_label': 'latin-en'},
+        {'name': None, 'name:en': None, 'name:fr': 'latin-fr', 'name:es': 'latin-es', 'name:de': 'latin-de', 'expected_label': 'latin-fr'},
+        {'name': None, 'name:en': None, 'name:fr': None, 'name:es': 'latin-es', 'name:de': 'latin-de', 'expected_label': 'latin-es'},
+        {'name': None, 'name:en': None, 'name:fr': None, 'name:es': None, 'name:de': 'latin-de', 'expected_label': 'latin-de'},
+        {'name': None, 'name:en': None, 'name:fr': None, 'name:es': None, 'name:de': None, 'expected_label': None},
 
-    # correct order of fallbacks with transliterate
-    {'name': xeno, 'name:en': 'latin-en', 'name:fr': 'latin-fr', 'name:es': 'latin-es', 'name:de': 'latin-de', 'expected_label': 'latin-en'},
-    {'name': xeno, 'name:en': None, 'name:fr': 'latin-fr', 'name:es': 'latin-es', 'name:de': 'latin-de', 'expected_label': 'latin-fr'},
-    {'name': xeno, 'name:en': None, 'name:fr': None, 'name:es': 'latin-es', 'name:de': 'latin-de', 'expected_label': 'latin-es'},
-    {'name': xeno, 'name:en': None, 'name:fr': None, 'name:es': None, 'name:de': 'latin-de', 'expected_label': 'latin-de'},
-    {'name': xeno, 'name:en': None, 'name:fr': None, 'name:es': None, 'name:de': None, 'expected_label': xeno_transliterated},
-])
+        # correct order of fallbacks with transliterate
+        {'name': xeno, 'name:en': 'latin-en', 'name:fr': 'latin-fr', 'name:es': 'latin-es', 'name:de': 'latin-de', 'expected_label': 'latin-en'},
+        {'name': xeno, 'name:en': None, 'name:fr': 'latin-fr', 'name:es': 'latin-es', 'name:de': 'latin-de', 'expected_label': 'latin-fr'},
+        {'name': xeno, 'name:en': None, 'name:fr': None, 'name:es': 'latin-es', 'name:de': 'latin-de', 'expected_label': 'latin-es'},
+        {'name': xeno, 'name:en': None, 'name:fr': None, 'name:es': None, 'name:de': 'latin-de', 'expected_label': 'latin-de'},
+        {'name': xeno, 'name:en': None, 'name:fr': None, 'name:es': None, 'name:de': None, 'expected_label': xeno_transliterated},
+    ]
+)
+
+
+@pytest.fixture(params=NAME_TAG_COMBINATIONS, ids=[str(tag_combination) for tag_combination in NAME_TAG_COMBINATIONS])
 def label_input(request):
-    return request.param.copy()
+    return dict(request.param)
 
 
 @slow

--- a/tests/inside_worker_test/label_sql_test.py
+++ b/tests/inside_worker_test/label_sql_test.py
@@ -367,6 +367,9 @@ def test_label_nonop(osmaxx_schemas, label_input):
     address_script_setup = 'sql/filter/nonop/000_setup-drop_and_recreate_table_nonop.sql'
     engine.execute(sqlalchemy.text(sql_from_bootstrap_relative_location(address_script_setup)).execution_options(autocommit=True))
 
+    additional_setup = 'sql/filter/nonop/005_lifecycle_view.sql'
+    engine.execute(sqlalchemy.text(sql_from_bootstrap_relative_location(additional_setup)).execution_options(autocommit=True))
+
     expected_label = label_input.pop('expected_label')
     label_input.update({'highway': 'planned'})
 

--- a/tests/inside_worker_test/nonop_way_test.py
+++ b/tests/inside_worker_test/nonop_way_test.py
@@ -11,10 +11,12 @@ from tests.inside_worker_test.declarative_schema import osm_models
 
 MAJOR_KEYS = frozenset({'highway', 'railway'})
 
-NON_LIFECYCLE_OSM_TAG_COMBINATIONS_AND_WAY_TYPES = (
-    (TagCombination(highway='track'), 'track'),
-    (TagCombination(highway='track', tracktype='grade3'), 'grade3'),
-    (TagCombination(highway='footway'), 'footway'),
+CORRESPONDING_OSMAXX_WAY_TYPES_FOR_OSM_TAG_COMBINATIONS = frozendict(
+    {
+        TagCombination(highway='track'): 'track',
+        TagCombination(highway='track', tracktype='grade3'): 'grade3',
+        TagCombination(highway='footway'): 'footway',
+    },
 )
 
 CORRESPONDING_OSMAXX_STATUSES_FOR_OSM_STATUSES = frozendict(
@@ -98,8 +100,8 @@ def expected_osmaxx_status(osm_status_and_expected_osmaxx_status):
 
 
 @pytest.fixture(
-    params=NON_LIFECYCLE_OSM_TAG_COMBINATIONS_AND_WAY_TYPES,
-    ids=[str(tag_combination) for tag_combination, _ in NON_LIFECYCLE_OSM_TAG_COMBINATIONS_AND_WAY_TYPES],
+    params=CORRESPONDING_OSMAXX_WAY_TYPES_FOR_OSM_TAG_COMBINATIONS.items(),
+    ids=[str(tag_combination) for tag_combination in CORRESPONDING_OSMAXX_WAY_TYPES_FOR_OSM_TAG_COMBINATIONS.keys()],
 )
 def non_lifecycle_osm_tags_and_expected_nonop_subtype(request):
     return request.param

--- a/tests/inside_worker_test/nonop_way_test.py
+++ b/tests/inside_worker_test/nonop_way_test.py
@@ -38,7 +38,8 @@ def test_osm_object_without_status_does_not_end_up_in_nonop(non_lifecycle_data_i
 
 @slow
 def test_osm_object_with_status_ends_up_in_nonop_with_correct_attribute_values(
-        lifecycle_data_import, nonop_l, expected_osmaxx_status, osm_status, non_lifecycle_osm_tags, major_tag_key, expected_nonop_subtype):
+        lifecycle_data_import, nonop_l, expected_osmaxx_status, osm_status, non_lifecycle_osm_tags, major_tag_key,
+        expected_nonop_subtype):
     engine = lifecycle_data_import
     with closing(engine.execute(sqlalchemy.select('*').select_from(nonop_l))) as result:
         assert result.rowcount == 1

--- a/tests/inside_worker_test/nonop_way_test.py
+++ b/tests/inside_worker_test/nonop_way_test.py
@@ -64,12 +64,17 @@ def non_lifecycle_data_import(non_lifecycle_data, data_import):
 
 
 @pytest.fixture
-def lifecycle_data(non_lifecycle_osm_tags, osm_status, major_tag_key):
+def lifecycle_data(lifecycle_osm_tags):
+    return {osm_models.t_osm_line: lifecycle_osm_tags}
+
+
+@pytest.fixture
+def lifecycle_osm_tags(non_lifecycle_osm_tags, osm_status, major_tag_key):
     osm_tags = dict(non_lifecycle_osm_tags)
     major_tag_value = osm_tags.pop(major_tag_key)
     osm_tags.update({major_tag_key: osm_status, 'tags': {osm_status: major_tag_value}})
     assert len(osm_tags) == len(non_lifecycle_osm_tags) + 1
-    return {osm_models.t_osm_line: osm_tags}
+    return osm_tags
 
 
 @pytest.fixture

--- a/tests/inside_worker_test/nonop_way_test.py
+++ b/tests/inside_worker_test/nonop_way_test.py
@@ -5,16 +5,17 @@ import pytest
 import sqlalchemy
 from sqlalchemy.sql.schema import Table as DbTable
 
+from osmaxx.utils.frozendict import frozendict
 from tests.inside_worker_test.conftest import slow
 from tests.inside_worker_test.declarative_schema import osm_models
 
 MAJOR_KEYS = frozenset({'highway', 'railway'})
-OSM_STATUSES_AND_CORRESPONDING_OSMAXX_STATUSES = [
-    ('planned', 'P'),
-    ('disused', 'D'),
-    ('construction', 'C'),
-    ('abandoned', 'A'),
-]
+CORRESPONDING_OSMAXX_STATUSES_FOR_OSM_STATUSES = frozendict(
+    planned='P',
+    disused='D',
+    construction='C',
+    abandoned='A',
+)
 
 
 @slow
@@ -106,8 +107,8 @@ def non_lifecycle_osm_tags_and_expected_nonop_subtype(request):
 
 
 @pytest.fixture(
-    params=OSM_STATUSES_AND_CORRESPONDING_OSMAXX_STATUSES,
-    ids=[osm_s for osm_s, _ in OSM_STATUSES_AND_CORRESPONDING_OSMAXX_STATUSES],
+    params=CORRESPONDING_OSMAXX_STATUSES_FOR_OSM_STATUSES.items(),
+    ids=list(CORRESPONDING_OSMAXX_STATUSES_FOR_OSM_STATUSES.keys()),
 )
 def osm_status_and_expected_osmaxx_status(request):
     return request.param

--- a/tests/inside_worker_test/nonop_way_test.py
+++ b/tests/inside_worker_test/nonop_way_test.py
@@ -36,12 +36,13 @@ def test_osm_object_without_status_does_not_end_up_in_nonop(non_lifecycle_data_i
 
 @slow
 def test_osm_object_with_status_ends_up_in_nonop_with_correct_attribute_values(
-        lifecycle_data_import, nonop_l, expected_osmaxx_status):
+        lifecycle_data_import, nonop_l, expected_osmaxx_status, osm_status, non_lifecycle_osm_tags, major_tag_key):
     engine = lifecycle_data_import
     with closing(engine.execute(sqlalchemy.select('*').select_from(nonop_l))) as result:
         assert result.rowcount == 1
         row = result.fetchone()
         assert row['status'] == expected_osmaxx_status
+        assert row['tags'] == '"{key}"=>"{value}"'.format(key=osm_status, value=non_lifecycle_osm_tags[major_tag_key])
 
 
 @pytest.fixture
@@ -65,7 +66,7 @@ def non_lifecycle_data_import(non_lifecycle_data, data_import):
 def lifecycle_data(non_lifecycle_osm_tags, osm_status, major_tag_key):
     osm_tags = dict(non_lifecycle_osm_tags)
     major_tag_value = osm_tags.pop(major_tag_key)
-    osm_tags.update({major_tag_key: osm_status, osm_status: major_tag_value})
+    osm_tags.update({major_tag_key: osm_status, 'tags': {osm_status: major_tag_value}})
     assert len(osm_tags) == len(non_lifecycle_osm_tags) + 1
     return {osm_models.t_osm_line: osm_tags}
 

--- a/tests/inside_worker_test/nonop_way_test.py
+++ b/tests/inside_worker_test/nonop_way_test.py
@@ -1,0 +1,117 @@
+from contextlib import closing
+from copy import deepcopy
+
+import pytest
+import sqlalchemy
+from sqlalchemy.sql.schema import Table as DbTable
+
+from tests.inside_worker_test.conftest import slow
+from tests.inside_worker_test.declarative_schema import osm_models
+
+MAJOR_KEYS = frozenset({'highway', 'railway'})
+
+
+@slow
+def test_osm_object_without_status_does_not_end_up_in_nonop(non_lifecycle_data_import, nonop_l):
+    engine = non_lifecycle_data_import
+    with closing(engine.execute(sqlalchemy.select('*').select_from(nonop_l))) as result:
+        assert result.rowcount == 0
+
+
+@slow
+def test_osm_object_with_status_ends_up_in_nonop(lifecycle_data_import, nonop_l):
+    engine = lifecycle_data_import
+    with closing(engine.execute(sqlalchemy.select('*').select_from(nonop_l))) as result:
+        assert result.rowcount == 1
+
+
+@pytest.fixture
+def nonop_l():
+    return DbTable('nonop_l', osm_models.metadata, schema='view_osmaxx')
+
+
+@pytest.yield_fixture
+def lifecycle_data_import(lifecycle_data, data_import):
+    with data_import(lifecycle_data) as engine:
+        yield engine
+
+
+@pytest.yield_fixture
+def non_lifecycle_data_import(non_lifecycle_data, data_import):
+    with data_import(non_lifecycle_data) as engine:
+        yield engine
+
+
+@pytest.fixture
+def lifecycle_data(non_lifecycle_osm_tags, osm_status):
+    major_keys = MAJOR_KEYS.intersection(non_lifecycle_osm_tags)
+    assert len(major_keys) == 1
+    major_tag_key = next(iter(major_keys))
+    osm_tags = deepcopy(non_lifecycle_osm_tags)
+    major_tag_value = osm_tags.pop(major_tag_key)
+    osm_tags.update({major_tag_key: osm_status, osm_status: major_tag_value})
+    assert len(osm_tags) == len(non_lifecycle_osm_tags) + 1
+    return {osm_models.t_osm_line: osm_tags}
+
+
+@pytest.fixture
+def non_lifecycle_data(non_lifecycle_osm_tags):
+    return {osm_models.t_osm_line: non_lifecycle_osm_tags}
+
+
+@pytest.fixture
+def non_lifecycle_osm_tags(non_lifecycle_osm_tags_and_expected_nonop_subtype):
+    osm_tags, _ = non_lifecycle_osm_tags_and_expected_nonop_subtype
+    return osm_tags
+
+
+@pytest.fixture
+def expected_nonop_subtype(non_lifecycle_osm_tags_and_expected_nonop_subtype):
+    _, subtype = non_lifecycle_osm_tags_and_expected_nonop_subtype
+    return subtype
+
+
+@pytest.fixture
+def osm_status(osm_status_and_expected_osmaxx_status):
+    status, _ = osm_status_and_expected_osmaxx_status
+    return status
+
+
+@pytest.fixture
+def expected_osmaxx_status(osm_status_and_expected_osmaxx_status):
+    _, osmaxx_status = osm_status_and_expected_osmaxx_status
+    return osmaxx_status
+
+
+@pytest.fixture(
+    params=[
+        (dict(highway='track'), 'track'),
+        (dict(highway='track', tracktype='grade3'), 'grade3'),
+        (dict(highway='footway'), 'footway'),
+    ],
+    ids=[
+        'highway=track',
+        'highway=track tracktype=grade3',
+        'highway=footway',
+    ],
+)
+def non_lifecycle_osm_tags_and_expected_nonop_subtype(request):
+    return request.param
+
+
+@pytest.fixture(
+    params=[
+        ('planned', 'P'),
+        ('disused', 'D'),
+        ('construction', 'C'),
+        ('abandoned', 'A'),
+    ],
+    ids=[
+        'planned',
+        'disused',
+        'construction',
+        'abandoned',
+    ],
+)
+def osm_status_and_expected_osmaxx_status(request):
+    return request.param

--- a/tests/inside_worker_test/nonop_way_test.py
+++ b/tests/inside_worker_test/nonop_way_test.py
@@ -21,8 +21,8 @@ CORRESPONDING_OSMAXX_WAY_TYPES_FOR_OSM_TAG_COMBINATIONS = frozendict(
 
 CORRESPONDING_OSMAXX_STATUSES_FOR_OSM_STATUSES = frozendict(
     planned='P',
-    disused='D',
     construction='C',
+    disused='D',
     abandoned='A',
 )
 

--- a/tests/inside_worker_test/nonop_way_test.py
+++ b/tests/inside_worker_test/nonop_way_test.py
@@ -16,6 +16,8 @@ CORRESPONDING_OSMAXX_WAY_TYPES_FOR_OSM_TAG_COMBINATIONS = frozendict(
         TagCombination(highway='track'): 'track',
         TagCombination(highway='track', tracktype='grade3'): 'grade3',
         TagCombination(highway='footway'): 'footway',
+        TagCombination(railway='rail'): 'rail',
+        TagCombination(railway='platform'): 'railway',
     },
 )
 
@@ -48,14 +50,14 @@ def test_osm_object_with_status_ends_up_in_nonop_with_correct_attribute_values(
 
 @slow
 def test_osm_object_with_status_without_details_ends_up_in_nonop_with_correct_status(
-        incomplete_lifecycle_data_import, nonop_l, expected_osmaxx_status):
+        incomplete_lifecycle_data_import, nonop_l, expected_osmaxx_status, major_tag_key):
     engine = incomplete_lifecycle_data_import
     with closing(engine.execute(sqlalchemy.select('*').select_from(nonop_l))) as result:
         assert result.rowcount == 1
         row = result.fetchone()
         assert row['status'] == expected_osmaxx_status
         assert row['tags'] is None
-        assert row['sub_type'] == 'road'
+        assert row['sub_type'] == dict(highway='road', railway='railway')[major_tag_key]
 
 
 @pytest.fixture

--- a/tests/inside_worker_test/nonop_way_test.py
+++ b/tests/inside_worker_test/nonop_way_test.py
@@ -69,6 +69,11 @@ def lifecycle_data(lifecycle_osm_tags):
 
 
 @pytest.fixture
+def non_lifecycle_data(non_lifecycle_osm_tags):
+    return {osm_models.t_osm_line: non_lifecycle_osm_tags}
+
+
+@pytest.fixture
 def lifecycle_osm_tags(non_lifecycle_osm_tags, osm_status, major_tag_key):
     osm_tags = dict(non_lifecycle_osm_tags)
     major_tag_value = osm_tags.pop(major_tag_key)
@@ -78,21 +83,16 @@ def lifecycle_osm_tags(non_lifecycle_osm_tags, osm_status, major_tag_key):
 
 
 @pytest.fixture
+def non_lifecycle_osm_tags(non_lifecycle_osm_tags_and_expected_nonop_subtype):
+    osm_tags, _ = non_lifecycle_osm_tags_and_expected_nonop_subtype
+    return osm_tags
+
+
+@pytest.fixture
 def major_tag_key(non_lifecycle_osm_tags):
     major_keys = MAJOR_KEYS.intersection(non_lifecycle_osm_tags)
     assert len(major_keys) == 1
     return next(iter(major_keys))
-
-
-@pytest.fixture
-def non_lifecycle_data(non_lifecycle_osm_tags):
-    return {osm_models.t_osm_line: non_lifecycle_osm_tags}
-
-
-@pytest.fixture
-def non_lifecycle_osm_tags(non_lifecycle_osm_tags_and_expected_nonop_subtype):
-    osm_tags, _ = non_lifecycle_osm_tags_and_expected_nonop_subtype
-    return osm_tags
 
 
 @pytest.fixture

--- a/tests/inside_worker_test/nonop_way_test.py
+++ b/tests/inside_worker_test/nonop_way_test.py
@@ -62,15 +62,19 @@ def non_lifecycle_data_import(non_lifecycle_data, data_import):
 
 
 @pytest.fixture
-def lifecycle_data(non_lifecycle_osm_tags, osm_status):
-    major_keys = MAJOR_KEYS.intersection(non_lifecycle_osm_tags)
-    assert len(major_keys) == 1
-    major_tag_key = next(iter(major_keys))
+def lifecycle_data(non_lifecycle_osm_tags, osm_status, major_tag_key):
     osm_tags = dict(non_lifecycle_osm_tags)
     major_tag_value = osm_tags.pop(major_tag_key)
     osm_tags.update({major_tag_key: osm_status, osm_status: major_tag_value})
     assert len(osm_tags) == len(non_lifecycle_osm_tags) + 1
     return {osm_models.t_osm_line: osm_tags}
+
+
+@pytest.fixture
+def major_tag_key(non_lifecycle_osm_tags):
+    major_keys = MAJOR_KEYS.intersection(non_lifecycle_osm_tags)
+    assert len(major_keys) == 1
+    return next(iter(major_keys))
 
 
 @pytest.fixture

--- a/tests/inside_worker_test/nonop_way_test.py
+++ b/tests/inside_worker_test/nonop_way_test.py
@@ -11,6 +11,11 @@ from tests.inside_worker_test.declarative_schema import osm_models
 
 MAJOR_KEYS = frozenset({'highway', 'railway'})
 
+EXPECTED_FALLBACK_SUBTYPE_FOR_MAJOR_KEY = frozendict(
+    highway='road',
+    railway='railway'
+)
+
 CORRESPONDING_OSMAXX_WAY_TYPES_FOR_OSM_TAG_COMBINATIONS = frozendict(
     {
         TagCombination(highway='track'): 'track',
@@ -58,7 +63,7 @@ def test_osm_object_with_status_without_details_ends_up_in_nonop_with_correct_st
         row = result.fetchone()
         assert row['status'] == expected_osmaxx_status
         assert row['tags'] is None
-        assert row['sub_type'] == dict(highway='road', railway='railway')[major_tag_key]
+        assert row['sub_type'] == EXPECTED_FALLBACK_SUBTYPE_FOR_MAJOR_KEY[major_tag_key]
 
 
 @pytest.fixture

--- a/tests/inside_worker_test/nonop_way_test.py
+++ b/tests/inside_worker_test/nonop_way_test.py
@@ -36,13 +36,14 @@ def test_osm_object_without_status_does_not_end_up_in_nonop(non_lifecycle_data_i
 
 @slow
 def test_osm_object_with_status_ends_up_in_nonop_with_correct_attribute_values(
-        lifecycle_data_import, nonop_l, expected_osmaxx_status, osm_status, non_lifecycle_osm_tags, major_tag_key):
+        lifecycle_data_import, nonop_l, expected_osmaxx_status, osm_status, non_lifecycle_osm_tags, major_tag_key, expected_nonop_subtype):
     engine = lifecycle_data_import
     with closing(engine.execute(sqlalchemy.select('*').select_from(nonop_l))) as result:
         assert result.rowcount == 1
         row = result.fetchone()
         assert row['status'] == expected_osmaxx_status
         assert row['tags'] == '"{key}"=>"{value}"'.format(key=osm_status, value=non_lifecycle_osm_tags[major_tag_key])
+        assert row['sub_type'] == expected_nonop_subtype
 
 
 @pytest.fixture

--- a/tests/inside_worker_test/nonop_way_test.py
+++ b/tests/inside_worker_test/nonop_way_test.py
@@ -9,6 +9,12 @@ from tests.inside_worker_test.conftest import slow
 from tests.inside_worker_test.declarative_schema import osm_models
 
 MAJOR_KEYS = frozenset({'highway', 'railway'})
+OSM_STATUSES_AND_CORRESPONDING_OSMAXX_STATUSES = [
+    ('planned', 'P'),
+    ('disused', 'D'),
+    ('construction', 'C'),
+    ('abandoned', 'A'),
+]
 
 
 @slow
@@ -100,18 +106,8 @@ def non_lifecycle_osm_tags_and_expected_nonop_subtype(request):
 
 
 @pytest.fixture(
-    params=[
-        ('planned', 'P'),
-        ('disused', 'D'),
-        ('construction', 'C'),
-        ('abandoned', 'A'),
-    ],
-    ids=[
-        'planned',
-        'disused',
-        'construction',
-        'abandoned',
-    ],
+    params=OSM_STATUSES_AND_CORRESPONDING_OSMAXX_STATUSES,
+    ids=[osm_s for osm_s, _ in OSM_STATUSES_AND_CORRESPONDING_OSMAXX_STATUSES],
 )
 def osm_status_and_expected_osmaxx_status(request):
     return request.param

--- a/tests/inside_worker_test/nonop_way_test.py
+++ b/tests/inside_worker_test/nonop_way_test.py
@@ -35,10 +35,13 @@ def test_osm_object_without_status_does_not_end_up_in_nonop(non_lifecycle_data_i
 
 
 @slow
-def test_osm_object_with_status_ends_up_in_nonop(lifecycle_data_import, nonop_l):
+def test_osm_object_with_status_ends_up_in_nonop_with_correct_attribute_values(
+        lifecycle_data_import, nonop_l, expected_osmaxx_status):
     engine = lifecycle_data_import
     with closing(engine.execute(sqlalchemy.select('*').select_from(nonop_l))) as result:
         assert result.rowcount == 1
+        row = result.fetchone()
+        assert row['status'] == expected_osmaxx_status
 
 
 @pytest.fixture


### PR DESCRIPTION
closes #423

we only handle
* [`<main tag key>=<status>`+`<status>=<main tag value>`, e.g. `highway=construction`+`construction=tertiary`](http://wiki.openstreetmap.org/wiki/Comparison_of_life_cycle_concepts#.3Ckey.3E_.3D_.3Cstatus.3E_.2B_.3Cstatus.3E_.3D_.3Cvalue.3E)
* `<main tag key>=<status>`, e.g. `highway=construction` (using the fallback `sub_type`s in this case)

[There are more lifecycle tagging schemes](http://wiki.openstreetmap.org/wiki/Comparison_of_life_cycle_concepts), most notable [lifecycle prefix](http://wiki.openstreetmap.org/wiki/Lifecycle_prefix) (`<status>:<main tag key>=<main tag value>`, e.g. `construction:highway=tertiary`) that we didn't handle before this PR and don't handle with it (yet), either.

### Reviewed by
- [x] @hixi
- [ ] @sfkeller