### PR TITLE
Fix #519: correctly filter abandoned ways

### DIFF
--- a/osmaxx/conversion/converters/converter_gis/bootstrap/sql/filter/railway/010_railway.sql
+++ b/osmaxx/conversion/converters/converter_gis/bootstrap/sql/filter/railway/010_railway.sql
@@ -41,4 +41,4 @@ INSERT INTO osmaxx.railway_l
     voltage as voltage,
     frequency as frequency
      FROM osm_line
-     WHERE railway not in ('abandon','construction','disused','planned');
+     WHERE railway not in ('abandoned','construction','disused','planned');

--- a/osmaxx/conversion/converters/converter_gis/bootstrap/sql/filter/road/010_road.sql
+++ b/osmaxx/conversion/converters/converter_gis/bootstrap/sql/filter/road/010_road.sql
@@ -61,7 +61,7 @@ INSERT INTO osmaxx.road_l
     else FALSE
     end as tunnel
      FROM osm_line
-     WHERE highway not in ('abandon','construction','planned','disused') or junction not in ('roundabout')
+     WHERE highway not in ('abandoned','construction','planned','disused') or junction not in ('roundabout')
 UNION
 (
   WITH osm_single_polygon AS (
@@ -137,5 +137,5 @@ UNION
     end as tunnel
 
      FROM osm_single_polygon
-     WHERE highway not in ('abandon','construction','planned','disused') or junction not in ('roundabout')
+     WHERE highway not in ('abandoned','construction','planned','disused') or junction not in ('roundabout')
 );


### PR DESCRIPTION
correctly filter abandoned ways from `road_l` and `railway_l`

(`abandon` is not a valid OSM lifecycle status.)

closes #519

### Reviewed by
- [x] @hixi
- [ ] @sfkeller