### PR TITLE
fix #574: use addr:city=* rather than addr:place=* as city in addresses

### DIFF
--- a/osmaxx/conversion/converters/converter_gis/bootstrap/sql/filter/address/010_address.sql
+++ b/osmaxx/conversion/converters/converter_gis/bootstrap/sql/filter/address/010_address.sql
@@ -32,7 +32,7 @@ INSERT INTO osmaxx.address_p
     end  as street,
     "addr:housenumber" as housenumber,
     "addr:postcode" as postcode,
-    "addr:place" as city,
+    "addr:city" as city,
     "addr:country" as country
   FROM osm_point
 where building !='entrance' and entrance is null and ("addr:street" !='' OR "addr:housenumber"!='' OR "addr:place"!='')
@@ -70,7 +70,7 @@ UNION
     end  as street,
     "addr:housenumber" as housenumber,
     "addr:postcode" as postcode,
-    "addr:place" as city,
+    "addr:city" as city,
     "addr:country" as country
   FROM osm_polygon
 where building !='entrance' and entrance is null and ("addr:street" !='' OR "addr:housenumber"!='' OR "addr:place"!='');

--- a/osmaxx/conversion/converters/converter_gis/bootstrap/sql/filter/address/020_entrance.sql
+++ b/osmaxx/conversion/converters/converter_gis/bootstrap/sql/filter/address/020_entrance.sql
@@ -35,7 +35,7 @@ INSERT INTO osmaxx.address_p
     end  as street,
     "addr:housenumber" as housenumber,
     "addr:postcode" as postcode,
-    "addr:place" as city,
+    "addr:city" as city,
     "addr:country" as country
   FROM osm_point
   where ("addr:street" !='' OR "addr:housenumber"!='' OR "addr:place"!='');

--- a/osmaxx/conversion/converters/converter_gis/bootstrap/sql/filter/address/030_interpolation.sql
+++ b/osmaxx/conversion/converters/converter_gis/bootstrap/sql/filter/address/030_interpolation.sql
@@ -37,7 +37,7 @@ INSERT INTO osmaxx.address_p
     temp_tbl.addr_street as street,
     temp_tbl.housenr as housenumber,
     osm_line."addr:postcode" as postcode,
-    osm_line."addr:place" as city,
+    osm_line."addr:city" as city,
     osm_line."addr:country" as country
  FROM temp_tbl
  INNER JOIN osm_line


### PR DESCRIPTION
fixes #574 

Use value of OSM tag `addr:city=*` rather than `addr:place=*` as attribute `city` in layer `address_p`.

### Reviewed by
- [x] @hixi
- [ ] @sfkeller