### PR TITLE
fix #567: export operative roundabouts only once

### DIFF
--- a/osmaxx/conversion/converters/converter_gis/bootstrap/sql/filter/road/010_road.sql
+++ b/osmaxx/conversion/converters/converter_gis/bootstrap/sql/filter/road/010_road.sql
@@ -61,7 +61,7 @@ INSERT INTO osmaxx.road_l
     else FALSE
     end as tunnel
      FROM osm_line
-     WHERE highway not in ('abandoned','construction','planned','proposed','disused') or junction not in ('roundabout')
+     WHERE highway not in ('abandoned','construction','planned','proposed','disused') AND junction IS DISTINCT FROM 'roundabout'
 UNION
 (
   WITH osm_single_polygon AS (
@@ -137,5 +137,5 @@ UNION
     end as tunnel
 
      FROM osm_single_polygon
-     WHERE highway not in ('abandoned','construction','planned','proposed','disused') or junction not in ('roundabout')
+     WHERE highway not in ('abandoned','construction','planned','proposed','disused') AND junction IS DISTINCT FROM 'roundabout'
 );

--- a/osmaxx/conversion/converters/converter_gis/bootstrap/sql/filter/road/020_junction.sql
+++ b/osmaxx/conversion/converters/converter_gis/bootstrap/sql/filter/road/020_junction.sql
@@ -54,7 +54,7 @@ INSERT INTO osmaxx.road_l
     end as tunnel
 
      FROM osm_line
-     WHERE junction='roundabout'
+     WHERE (highway IS NULL OR highway NOT IN ('abandoned','construction','planned','proposed','disused')) AND junction = 'roundabout'
 UNION
 (
   WITH osm_single_polygon AS (
@@ -119,5 +119,5 @@ UNION
     else FALSE
     end as tunnel
      FROM osm_single_polygon
-     WHERE junction='roundabout'
+     WHERE (highway IS NULL OR highway NOT IN ('abandoned','construction','planned','proposed','disused')) AND junction = 'roundabout'
 );

--- a/tests/inside_worker_test/nonop_way_test.py
+++ b/tests/inside_worker_test/nonop_way_test.py
@@ -21,6 +21,7 @@ CORRESPONDING_OSMAXX_WAY_TYPES_FOR_OSM_TAG_COMBINATIONS = frozendict(
         TagCombination(highway='track'): 'track',
         TagCombination(highway='track', tracktype='grade3'): 'grade3',
         TagCombination(highway='footway'): 'footway',
+        TagCombination(highway='secondary', junction='roundabout'): 'secondary',
         TagCombination(railway='rail'): 'rail',
         TagCombination(railway='platform'): 'railway',
     },


### PR DESCRIPTION
fixes #567
also partially fixes #565: non-operative roundabouts now only present in `nonop_l`, not in `road_l`

### Reviewed by
- [x] @hixi
- [ ] @sfkeller